### PR TITLE
Help Travis-CI tell Coveralls to combine all tests via parallel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,29 @@
+# Send final notification to coveralls after all jobs have been completed.
+notifications:
+  webhooks: https://coveralls.io/webhook
+
 matrix:
   include:
-  - language: java
+  - name: "Java Tests"
+    language: java
     jdk: oraclejdk8
+    before_script:
+      - export COVERALLS_PARALLEL=true
     install:
       - mvn test-compile -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     after_success:
-      - mvn clean test cobertura:cobertura jacoco:report coveralls:report
+      - mvn clean test cobertura:cobertura jacoco:report coveralls:report -DserviceName="travis-ci" -DserviceBuildNumber=$TRAVIS_BUILD_NUMBER
 
-  - language: node_js
+  - name: "Node/Javascript Tests"
+    language: node_js
     node_js: "6"
     addons:
       - chrome: stable
     before_script:
       - export DISPLAY=:99.0
+      - export COVERALLS_PARALLEL=true
+      - export CI_NAME="travis-ci"
+      - export CI_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
       - sh -e /etc/init.d/xvfb start
       - npm start > /dev/null &
       - npm run update-webdriver


### PR DESCRIPTION
The coverage report is not being correctly combined and coveralls would only pick one or the other as the number.
By utilizing parallel builds, coveralls knows that the test results should be combined.

Webhooks and a few environmental variables are required to achieve this.
Maven happens to directly support assignment of the build settings.
Karma needs the environmental variables assigned.

see: https://docs.coveralls.io/parallel-build-webhook
see: https://travis-ci.community/t/how-can-i-share-coverage-information-between-build-stages-in-prs-from-forks/859/12