### PR TITLE
[D-01276] Restrict NULL values from being used, for Sources and Writers

### DIFF
--- a/src/main/java/edu/tamu/sage/model/Source.java
+++ b/src/main/java/edu/tamu/sage/model/Source.java
@@ -2,6 +2,7 @@ package edu.tamu.sage.model;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -11,20 +12,25 @@ import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 @Entity
 public class Source extends ValidatingBaseEntity implements Sourcable {
     //TODO Query the SOLR Core for its fields to provide Readers/Writers with a list of fields to choose from for mapping to the internal metadata fields
-    @Column(unique = true)
+    @NotNull
+    @Column(unique = true, nullable = false)
     private String name;
 
-    @Column
+    @NotNull
+    @Column(nullable = false)
     private String uri;
 
-    @Column
+    @NotNull
+    @Column(nullable = false)
     private String username;
 
+    // @JsonIgnore prevents @NotNull and nullable = false from being used here.
     @Column
     @JsonIgnore
     private String password;
 
-    @Column
+    @NotNull
+    @Column(nullable = false)
     private Boolean readOnly;
 
     public Source() {

--- a/src/main/java/edu/tamu/sage/model/Writer.java
+++ b/src/main/java/edu/tamu/sage/model/Writer.java
@@ -9,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
@@ -18,7 +19,8 @@ import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 
 @Entity
 public class Writer extends ValidatingBaseEntity implements Writable {
-    @Column(unique=true)
+    @NotNull
+    @Column(unique=true, nullable=false)
     private String name;
 
     @ManyToOne

--- a/src/main/webapp/app/repo/sourceRepo.js
+++ b/src/main/webapp/app/repo/sourceRepo.js
@@ -4,7 +4,9 @@ sage.repo("SourceRepo", function (Source, WsApi) {
   sourceRepo.scaffold = new Source({
     name: "Local Solr",
     uri: "http://localhost:8983/solr/collection1",
-    readOnly: true
+    readOnly: true,
+    username: "",
+    password: ""
   });
 
   sourceRepo.getAvailableFields = function (uri, filter) {

--- a/src/main/webapp/app/repo/writerRepo.js
+++ b/src/main/webapp/app/repo/writerRepo.js
@@ -1,5 +1,9 @@
 sage.repo("WriterRepo", function(Writer, WsApi) {
   var writerRepo = this;
 
+  writerRepo.scaffold = {
+    name: ""
+  };
+
   return writerRepo;
 });


### PR DESCRIPTION
Use `@NotNull` to utilize the validation on NULL values received.
Use `nullable = false` on the `@Column` to setup the database with `NOT NULL` column property.
Assign defaults to the scaffold to ensure NULL is never sent by the frontend.