### PR TITLE
[B-03915] Handle exception when source cannot be reached and provide feedback to frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ng-openseadragon": "1.3.5",
     "ng-table": "3.0.1",
     "openseadragon": "2.4.0",
-    "weaver-ui-core": "git+https://github.com/TAMULib/Weaver-UI-Core.git#v2.0.2"
+    "weaver-ui-core": "git+https://github.com/TAMULib/Weaver-UI-Core.git#v2.0.4"
   },
   "devDependencies": {
     "grunt": "1.0.3",

--- a/src/main/java/edu/tamu/sage/controller/handler/SourceControllerAdvice.java
+++ b/src/main/java/edu/tamu/sage/controller/handler/SourceControllerAdvice.java
@@ -1,0 +1,52 @@
+package edu.tamu.sage.controller.handler;
+
+import static edu.tamu.weaver.response.ApiStatus.ERROR;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.tamu.sage.exceptions.SourceFieldsException;
+import edu.tamu.sage.exceptions.SourceNotFoundException;
+import edu.tamu.sage.exceptions.SourceServiceException;
+import edu.tamu.weaver.response.ApiResponse;
+
+@RestController
+@ControllerAdvice
+public class SourceControllerAdvice {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @ExceptionHandler(SourceFieldsException.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public ApiResponse handleSourceFieldsException(SourceFieldsException exception) {
+        String message = exception.getMessage().length() == 0 ? "Failed to process source fields." : exception.getMessage();
+        logger.debug(message, exception);
+        return new ApiResponse(ERROR, message);
+    }
+
+    @ExceptionHandler(SourceNotFoundException.class)
+    @ResponseStatus(value = HttpStatus.SERVICE_UNAVAILABLE)
+    @ResponseBody
+    public ApiResponse handleSourceNotFoundException(SourceNotFoundException exception) {
+        String message = exception.getMessage().length() == 0 ? "Failed to connect to source service." : exception.getMessage();
+        logger.debug(message, exception);
+        return new ApiResponse(ERROR, message);
+    }
+
+    @ExceptionHandler(SourceServiceException.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public ApiResponse handleSourceServiceException(SourceServiceException exception) {
+        String message = exception.getMessage().length() == 0 ? "Failed to access source service." : exception.getMessage();
+        logger.debug(message, exception);
+        return new ApiResponse(ERROR, message);
+    }
+
+}

--- a/src/main/java/edu/tamu/sage/exceptions/SourceFieldsException.java
+++ b/src/main/java/edu/tamu/sage/exceptions/SourceFieldsException.java
@@ -1,8 +1,16 @@
 package edu.tamu.sage.exceptions;
 
-public class SourceFieldsException extends Exception {
+public class SourceFieldsException extends SourceServiceException {
 
     private static final long serialVersionUID = 8294513392525596154L;
+
+    public SourceFieldsException() {
+        super();
+    }
+
+    public SourceFieldsException(String message) {
+        super(message);
+    }
 
     public SourceFieldsException(String message, Throwable e) {
         super(message, e);

--- a/src/main/java/edu/tamu/sage/exceptions/SourceNotFoundException.java
+++ b/src/main/java/edu/tamu/sage/exceptions/SourceNotFoundException.java
@@ -1,0 +1,19 @@
+package edu.tamu.sage.exceptions;
+
+public class SourceNotFoundException extends SourceServiceException {
+
+    private static final long serialVersionUID = -276094005758215635L;
+
+    public SourceNotFoundException() {
+        super();
+    }
+
+    public SourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public SourceNotFoundException(String message, Throwable e) {
+        super(message, e);
+    }
+
+}

--- a/src/main/java/edu/tamu/sage/exceptions/SourceServiceException.java
+++ b/src/main/java/edu/tamu/sage/exceptions/SourceServiceException.java
@@ -1,0 +1,19 @@
+package edu.tamu.sage.exceptions;
+
+public class SourceServiceException extends RuntimeException {
+
+    private static final long serialVersionUID = -546174397174413716L;
+
+    public SourceServiceException() {
+        super();
+    }
+
+    public SourceServiceException(String message) {
+        super(message);
+    }
+
+    public SourceServiceException(String message, Throwable e) {
+        super(message, e);
+    }
+
+}

--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import edu.tamu.sage.exceptions.DiscoveryContextBuildException;
 import edu.tamu.sage.exceptions.SourceFieldsException;
+import edu.tamu.sage.exceptions.SourceServiceException;
 import edu.tamu.sage.model.DiscoveryView;
 import edu.tamu.sage.model.FacetFields;
 import edu.tamu.sage.model.MetadataField;
@@ -172,8 +173,8 @@ public class SolrDiscoveryService {
         String filter = discoveryView.getFilter();
         try {
             return solrSourceService.getAvailableFields(uri, filter);
-        } catch (SourceFieldsException e) {
-            throw new DiscoveryContextBuildException("Could not populate fields", e);
+        } catch (SourceServiceException e) {
+            throw new DiscoveryContextBuildException("Could not populate fields, uri: " + uri, e);
         }
     }
 

--- a/src/main/java/edu/tamu/sage/service/SolrSourceService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrSourceService.java
@@ -1,5 +1,6 @@
 package edu.tamu.sage.service;
 
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -8,6 +9,7 @@ import java.util.stream.Collectors;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.LukeRequest;
 import org.apache.solr.client.solrj.response.LukeResponse;
@@ -16,6 +18,8 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.springframework.stereotype.Service;
 
 import edu.tamu.sage.exceptions.SourceFieldsException;
+import edu.tamu.sage.exceptions.SourceNotFoundException;
+import edu.tamu.sage.exceptions.SourceServiceException;
 import edu.tamu.sage.model.response.SolrField;
 
 @Service
@@ -24,7 +28,7 @@ public class SolrSourceService implements SourceService {
     public final static String ALL_FIELDS_KEY = "all_fields";
 
     @Override
-    public List<SolrField> getAvailableFields(String uri, String filter) throws SourceFieldsException {
+    public List<SolrField> getAvailableFields(String uri, String filter) throws SourceServiceException {
         List<SolrField> availableFields = new ArrayList<SolrField>();
         SolrField defaultField = new SolrField();
         // TODO: ensure type is actual Solr datatype for text
@@ -48,23 +52,27 @@ public class SolrSourceService implements SourceService {
                     }
                 }
             }
+        } catch (ConnectException | SolrServerException e) {
+            throw new SourceNotFoundException("Could not connect to the core, uri: " + uri, e);
         } catch (Exception e) {
-            throw new SourceFieldsException("Could not populate fields", e);
+            throw new SourceFieldsException("Could not populate fields, uri: " + uri, e);
         }
 
         return availableFields;
     }
 
     @Override
-    public List<SolrField> getIndexedFields(String uri, String filter) throws SourceFieldsException {
+    public List<SolrField> getIndexedFields(String uri, String filter) throws SourceServiceException {
         try (SolrClient solr = new HttpSolrClient(uri)) {
             LukeRequest luke = new LukeRequest();
             luke.setNumTerms(0);
             LukeResponse lr = luke.process(solr);
             Map<String, FieldInfo> map = lr.getFieldInfo();
             return map.values().stream().filter(info -> isIndexed(info)).map(info -> SolrField.of(info)).collect(Collectors.toList());
+        } catch (ConnectException | SolrServerException e) {
+            throw new SourceNotFoundException("Could not connect to the core, uri: " + uri, e);
         } catch (Exception e) {
-            throw new SourceFieldsException("Could not populate fields", e);
+            throw new SourceFieldsException("Could not populate fields, uri: " + uri, e);
         }
     }
 

--- a/src/main/java/edu/tamu/sage/service/SourceService.java
+++ b/src/main/java/edu/tamu/sage/service/SourceService.java
@@ -2,13 +2,13 @@ package edu.tamu.sage.service;
 
 import java.util.List;
 
-import edu.tamu.sage.exceptions.SourceFieldsException;
+import edu.tamu.sage.exceptions.SourceServiceException;
 import edu.tamu.sage.model.response.SolrField;
 
 public interface SourceService {
 
-	public List<SolrField> getAvailableFields(String uri, String filter) throws SourceFieldsException;
-	
-	public List<SolrField> getIndexedFields(String uri, String filter) throws SourceFieldsException;
+	public List<SolrField> getAvailableFields(String uri, String filter) throws SourceServiceException;
+
+	public List<SolrField> getIndexedFields(String uri, String filter) throws SourceServiceException;
 
 }

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -4,6 +4,7 @@
     <h4 class="modal-title">Create Discovery View</h4>
   </div>
   <div class="modal-body">
+    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -4,7 +4,6 @@
     <h4 class="modal-title">Create Discovery View</h4>
   </div>
   <div class="modal-body">
-
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">
@@ -22,7 +21,7 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedselect
               model="discoveryViewToCreate"
               property="source"
@@ -35,7 +34,7 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedselect>
-    
+
             <validatedinput
               model="discoveryViewToCreate"
               property="filter"
@@ -46,7 +45,7 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedinput
               model="discoveryViewToCreate"
               property="slug"
@@ -86,7 +85,7 @@
               label="Info Text"
               form="discoveryViewForms.create"
               validations="discoveryViewForms.validations"
-              results="discoveryViewForms.getResults()"> 
+              results="discoveryViewForms.getResults()">
             </validatedtextarea>
 
           </div>
@@ -116,12 +115,12 @@
               </validatedselect>
             </div>
             <div class="col-sm-5">
-              <multi-suggestion-input 
+              <multi-suggestion-input
                 model="discoveryViewToCreate"
                 property="titleKey"
                 optionproperty="name"
                 suggestions="fields"
-                name="titleKey"                
+                name="titleKey"
                 label="Title Key"
                 placeholder="'{{' to see Title Key suggesions">
               </multi-suggestion-input>
@@ -129,23 +128,23 @@
           </div>
           <div class="row">
               <div class="col-sm-5 col-sm-offset-1">
-                <multi-suggestion-input 
+                <multi-suggestion-input
                   model="discoveryViewToCreate"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceThumbnailUriKey"                
+                  name="resourceThumbnailUriKey"
                   label="Thumbnail Uri Key"
                   placeholder="'{{' to see Thumbnail Uri Key suggesions">
                 </multi-suggestion-input>
               </div>
               <div class="col-sm-5">
-                <multi-suggestion-input 
+                <multi-suggestion-input
                   model="discoveryViewToCreate"
                   property="resourceLocationUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceUriKey"                
+                  name="resourceUriKey"
                   label="Resource Key"
                   placeholder="'{{' to see Resource Key suggesions">
                 </multi-suggestion-input>

--- a/src/main/webapp/app/views/modals/createInternalMetadatumModal.html
+++ b/src/main/webapp/app/views/modals/createInternalMetadatumModal.html
@@ -5,6 +5,7 @@
   </div>
   <div class="modal-body">
     <validationmessage results="internalMetadatumForms.getResults()"></validationmessage>
+
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <validatedinput

--- a/src/main/webapp/app/views/modals/createJobModal.html
+++ b/src/main/webapp/app/views/modals/createJobModal.html
@@ -3,7 +3,6 @@
     <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelCreateJob()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Create Job</h4>
   </div>
-
   <div class="modal-body">
     <validationmessage results="jobForms.getResults()"></validationmessage>
 

--- a/src/main/webapp/app/views/modals/createOperatorModal.html
+++ b/src/main/webapp/app/views/modals/createOperatorModal.html
@@ -5,6 +5,7 @@
   </div>
   <div class="modal-body">
     <validationmessage results="operatorForms.getResults()"></validationmessage>
+
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <validatedinput

--- a/src/main/webapp/app/views/modals/createReaderModal.html
+++ b/src/main/webapp/app/views/modals/createReaderModal.html
@@ -4,6 +4,7 @@
     <h4 class="modal-title">Create Reader</h4>
   </div>
   <div class="modal-body">
+    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="readerForms.getResults()"></validationmessage>
 
     <div class="row">

--- a/src/main/webapp/app/views/modals/createSourceModal.html
+++ b/src/main/webapp/app/views/modals/createSourceModal.html
@@ -4,7 +4,6 @@
     <h4 class="modal-title">Create Core</h4>
   </div>
   <div class="modal-body">
-
     <validationmessage results="sourceForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">

--- a/src/main/webapp/app/views/modals/createWriterModal.html
+++ b/src/main/webapp/app/views/modals/createWriterModal.html
@@ -4,8 +4,9 @@
     <h4 class="modal-title">Create Writer</h4>
   </div>
   <div class="modal-body">
-
+    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="writerForms.getResults()"></validationmessage>
+
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <validatedinput

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -4,6 +4,7 @@
     <h4 class="modal-title">Edit Discovery View</h4>
   </div>
   <div class="modal-body">
+    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -4,7 +4,6 @@
     <h4 class="modal-title">Edit Discovery View</h4>
   </div>
   <div class="modal-body">
-
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">
@@ -22,7 +21,7 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedselect
               model="discoveryViewToUpdate"
               property="source"
@@ -35,7 +34,7 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedselect>
-    
+
             <validatedinput
               model="discoveryViewToUpdate"
               property="filter"
@@ -46,7 +45,7 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedinput
               model="discoveryViewToUpdate"
               property="slug"
@@ -86,7 +85,7 @@
               label="Info Text"
               form="discoveryViewForms.update"
               validations="discoveryViewForms.validations"
-              results="discoveryViewForms.getResults()"> 
+              results="discoveryViewForms.getResults()">
             </validatedtextarea>
 
           </div>
@@ -116,12 +115,12 @@
               </validatedselect>
             </div>
             <div class="col-sm-5">
-              <multi-suggestion-input 
+              <multi-suggestion-input
                 model="discoveryViewToUpdate"
                 property="titleKey"
                 optionproperty="name"
                 suggestions="fields"
-                name="titleKey"                
+                name="titleKey"
                 label="Title Key"
                 placeholder="'{{' to see Title Key suggesions">
               </multi-suggestion-input>
@@ -129,23 +128,23 @@
           </div>
           <div class="row">
               <div class="col-sm-5 col-sm-offset-1">
-                <multi-suggestion-input 
+                <multi-suggestion-input
                   model="discoveryViewToUpdate"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceThumbnailUriKey"                
+                  name="resourceThumbnailUriKey"
                   label="Thumbnail Uri Key"
                   placeholder="'{{' to see Thumbnail Uri Key suggesions">
                 </multi-suggestion-input>
               </div>
               <div class="col-sm-5">
-                <multi-suggestion-input 
+                <multi-suggestion-input
                   model="discoveryViewToUpdate"
                   property="resourceLocationUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceUriKey"                
+                  name="resourceUriKey"
                   label="Resource Key"
                   placeholder="'{{' to see Resource Key suggesions">
                 </multi-suggestion-input>

--- a/src/main/webapp/app/views/modals/updateInternalMetadatumModal.html
+++ b/src/main/webapp/app/views/modals/updateInternalMetadatumModal.html
@@ -5,6 +5,7 @@
   </div>
   <div class="modal-body">
     <validationmessage results="internalMetadatumForms.getResults()"></validationmessage>
+
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <validatedinput

--- a/src/main/webapp/app/views/modals/updateJobModal.html
+++ b/src/main/webapp/app/views/modals/updateJobModal.html
@@ -3,7 +3,6 @@
     <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelUpdateJob()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Update Job</h4>
   </div>
-
   <div class="modal-body">
     <validationmessage results="jobForms.getResults()"></validationmessage>
 

--- a/src/main/webapp/app/views/modals/updateJobScheduleModal.html
+++ b/src/main/webapp/app/views/modals/updateJobScheduleModal.html
@@ -3,7 +3,6 @@
     <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelUpdateJobSchedule()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Update Job Schedule</h4>
   </div>
-
   <div class="modal-body">
 
     <div class="row form-group">

--- a/src/main/webapp/app/views/modals/updateOperatorModal.html
+++ b/src/main/webapp/app/views/modals/updateOperatorModal.html
@@ -5,6 +5,7 @@
   </div>
   <div class="modal-body">
     <validationmessage results="operatorForms.getResults()"></validationmessage>
+
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
         <validatedinput

--- a/src/main/webapp/app/views/modals/updateReaderModal.html
+++ b/src/main/webapp/app/views/modals/updateReaderModal.html
@@ -4,6 +4,7 @@
     <h4 class="modal-title">Update Reader</h4>
   </div>
   <div class="modal-body">
+    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="readerForms.getResults()"></validationmessage>
 
     <div class="row">

--- a/src/main/webapp/app/views/modals/updateWriterModal.html
+++ b/src/main/webapp/app/views/modals/updateWriterModal.html
@@ -4,6 +4,7 @@
     <h4 class="modal-title">Update Writer</h4>
   </div>
   <div class="modal-body">
+    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="writerForms.getResults()"></validationmessage>
 
     <div class="row">


### PR DESCRIPTION
Implement generic `SourceServiceException`.
Implement specific Exceptions: `SourceFieldsException` and `SourceNotFoundException`.

Give the user explicit feedback when unable to connect to the service and use a **HTTP 503**.
For all other source errors, use `SourceServiceException` with the less explicit **HTTP 500**.

The URI is provided as a simple way to provide which source failed.
(It may or may not be more desirable to use the source name and not the URI.)

Make sure the appropriate modals exclusively receive the core exceptions.
Set timeout of errors to 30 seconds.

depends: TAMULib/Weaver-UI-Core#145.