### PR TITLE
[D-01282] Use simpler import.sql, fixing ability to insert Internal Metadata Management

### DIFF
--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,11 +1,11 @@
-INSERT INTO INTERNAL_METADATA SELECT * FROM (
-  SELECT 1, 'id', 'Id', true UNION
-  SELECT 2, 'title', 'Title', true UNION
-  SELECT 3, 'creator', 'Creator', false UNION
-  SELECT 4, 'created', 'Created', false UNION
-  SELECT 5, 'subject', 'Subject', false UNION
-  SELECT 6, 'format', 'Format', false UNION
-  SELECT 7, 'language', 'Language', false UNION
-  SELECT 8, 'terms.identifier', 'Identifier', false UNION
-  SELECT 9, 'isPartOf', 'Part Of', false
-) M WHERE NOT EXISTS(SELECT * FROM INTERNAL_METADATA);
+INSERT INTO INTERNAL_METADATA (FIELD, GLOSS, REQUIRED) VALUES
+  ( 'id', 'Id', true ),
+  ( 'title', 'Title', true ),
+  ( 'creator', 'Creator', false ),
+  ( 'created', 'Created', false ),
+  ( 'subject', 'Subject', false ),
+  ( 'format', 'Format', false ),
+  ( 'language', 'Language', false ),
+  ( 'terms.identifier', 'Identifier', false ),
+  ( 'isPartOf', 'Part Of', false )
+;


### PR DESCRIPTION
Do not manually insert the ID column because that is a SERIAL/AUTO-INCREMENT column.
Manually adding it prevents the auto-increment column from working.
Specifically, the auto-incremented column ends up still having a value of 1 after the initial import and further attempts in the UI to add any metadata will fail due to id conflicts.

Do not check to see if columns are already imported.
The property `spring.datasource.data: classpath:/import.sql` should be disabled after the initial import to prevent further inserts.
(It is a shame that `spring.jpa.hibernate.ddl-auto` doesn't also respect/handle `spring.datasource.data`.)