### PR TITLE
[B-03968, D-01278, B-03887] Discovery views is broken and Search tab for Discovery View creation

### DIFF
--- a/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
+++ b/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
@@ -84,7 +84,7 @@ public class DiscoveryViewController {
 
     @RequestMapping(value = "/context/{slug}", method = RequestMethod.GET)
     @PreAuthorize("hasRole('ANONYMOUS')")
-    public ApiResponse findBySlug(@PathVariable String slug, @RequestParam("field") String field, @RequestParam("value") String value, @PageableDefault(page=0, size=10) Pageable page, @RequestParam("offset") int offset, @RequestParam Map<String, String> filterMap) throws DiscoveryContextNotFoundException, UnsupportedEncodingException, DiscoveryContextBuildException {
+    public ApiResponse findBySlug(@PathVariable String slug, @RequestParam(name = "field", defaultValue = "") String field, @RequestParam(name = "value", defaultValue = "") String value, @PageableDefault(page=0, size=10) Pageable page, @RequestParam(name = "offset", defaultValue = "0") int offset, @RequestParam Map<String, String> filterMap) throws DiscoveryContextNotFoundException, UnsupportedEncodingException, DiscoveryContextBuildException {
         DiscoveryView discoveryView = discoveryViewRepo.findOneBySlug(slug);
         if (discoveryView == null) {
             throw new DiscoveryContextNotFoundException(String.format("Could not find Discovery Context for %s", slug));
@@ -97,7 +97,7 @@ public class DiscoveryViewController {
         filterMap.remove("sort");
         filterMap.remove("offset");
 
-        return new ApiResponse(SUCCESS, solrDiscoveryService.buildDiscoveryContext(discoveryView, field == null ? "" : field, value == null ? "" : value, page, offset, filterMap));
+        return new ApiResponse(SUCCESS, solrDiscoveryService.buildDiscoveryContext(discoveryView, field, value, page, offset, filterMap));
     }
 
     @RequestMapping(value = "/context/{slug}/{resultId}", method = RequestMethod.GET)

--- a/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
+++ b/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
@@ -6,11 +6,14 @@ import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -81,17 +84,20 @@ public class DiscoveryViewController {
 
     @RequestMapping(value = "/context/{slug}", method = RequestMethod.GET)
     @PreAuthorize("hasRole('ANONYMOUS')")
-    public ApiResponse findBySlug(@PathVariable String slug, @RequestParam Map<String, String> filterMap, @RequestParam("rows") int rows, @RequestParam("start") int start, @RequestParam("sort") String sort) throws DiscoveryContextNotFoundException, DiscoveryContextBuildException, JsonProcessingException, IOException {
-
-        filterMap.remove("rows");
-        filterMap.remove("start");
-        filterMap.remove("sort");
-
+    public ApiResponse findBySlug(@PathVariable String slug, @RequestParam("field") String field, @RequestParam("value") String value, @PageableDefault(page=0, size=10) Pageable page, @RequestParam("offset") int offset, @RequestParam Map<String, String> filterMap) throws DiscoveryContextNotFoundException, UnsupportedEncodingException, DiscoveryContextBuildException {
         DiscoveryView discoveryView = discoveryViewRepo.findOneBySlug(slug);
         if (discoveryView == null) {
             throw new DiscoveryContextNotFoundException(String.format("Could not find Discovery Context for %s", slug));
         }
-        return new ApiResponse(SUCCESS, solrDiscoveryService.buildDiscoveryContext(discoveryView, filterMap, rows, start, sort));
+
+        filterMap.remove("field");
+        filterMap.remove("value");
+        filterMap.remove("page");
+        filterMap.remove("size");
+        filterMap.remove("sort");
+        filterMap.remove("offset");
+
+        return new ApiResponse(SUCCESS, solrDiscoveryService.buildDiscoveryContext(discoveryView, field == null ? "" : field, value == null ? "" : value, page, offset, filterMap));
     }
 
     @RequestMapping(value = "/context/{slug}/{resultId}", method = RequestMethod.GET)
@@ -102,7 +108,7 @@ public class DiscoveryViewController {
         if (discoveryView == null) {
             throw new DiscoveryContextNotFoundException(String.format("Could not find Discovery Context for %s", slug));
         }
-        return new ApiResponse(SUCCESS, solrDiscoveryService.getSinlgeResult(discoveryView, resultId));
+        return new ApiResponse(SUCCESS, solrDiscoveryService.getSingleResult(discoveryView, resultId));
     }
 
 }

--- a/src/main/java/edu/tamu/sage/model/DiscoveryView.java
+++ b/src/main/java/edu/tamu/sage/model/DiscoveryView.java
@@ -7,6 +7,8 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
+import javax.persistence.OrderBy;
+import javax.persistence.OrderColumn;
 
 import edu.tamu.sage.model.validation.DiscoveryViewValidator;
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
@@ -50,6 +52,7 @@ public class DiscoveryView extends ValidatingBaseEntity {
     private String infoText;
 
     @NotNull
+    @OrderBy(value = "search_fields_order ASC")
     @Column(nullable = false)
     private String infoLinkText;
 
@@ -62,6 +65,10 @@ public class DiscoveryView extends ValidatingBaseEntity {
 
     @ElementCollection
     private List<FacetFields> facetFields;
+
+    @OrderColumn
+    @ElementCollection
+    private List<SearchField> searchFields;
 
     public DiscoveryView() {
         setModelValidator(new DiscoveryViewValidator());
@@ -185,12 +192,31 @@ public class DiscoveryView extends ValidatingBaseEntity {
         return f;
     }
 
+    public SearchField findSearchFieldByKey(String key) {
+        SearchField searchField = null;
+        for (SearchField sf : searchFields) {
+            if (sf.getKey().equals(key)) {
+                searchField = sf;
+                break;
+            }
+        }
+        return searchField;
+    }
+
     public List<FacetFields> getFacetFields() {
         return facetFields;
     }
 
     public void setFacetFields(List<FacetFields> facetFields) {
         this.facetFields = facetFields;
+    }
+
+    public List<SearchField> getSearchFields() {
+        return searchFields;
+    }
+
+    public void setSearchFields(List<SearchField> searchFields) {
+        this.searchFields = searchFields;
     }
 
 }

--- a/src/main/java/edu/tamu/sage/model/DiscoveryView.java
+++ b/src/main/java/edu/tamu/sage/model/DiscoveryView.java
@@ -6,9 +6,8 @@ import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
-import javax.validation.constraints.NotNull;
-import javax.persistence.OrderBy;
 import javax.persistence.OrderColumn;
+import javax.validation.constraints.NotNull;
 
 import edu.tamu.sage.model.validation.DiscoveryViewValidator;
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;

--- a/src/main/java/edu/tamu/sage/model/DiscoveryView.java
+++ b/src/main/java/edu/tamu/sage/model/DiscoveryView.java
@@ -52,7 +52,6 @@ public class DiscoveryView extends ValidatingBaseEntity {
     private String infoText;
 
     @NotNull
-    @OrderBy(value = "search_fields_order ASC")
     @Column(nullable = false)
     private String infoLinkText;
 

--- a/src/main/java/edu/tamu/sage/model/SearchField.java
+++ b/src/main/java/edu/tamu/sage/model/SearchField.java
@@ -1,0 +1,38 @@
+package edu.tamu.sage.model;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class SearchField {
+
+    private String key;
+
+    private String label;
+
+    public SearchField() {
+        super();
+    }
+
+    public SearchField(String key, String label) {
+        super();
+        this.key = key;
+        this.label = label;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+}

--- a/src/main/java/edu/tamu/sage/model/response/DiscoveryContext.java
+++ b/src/main/java/edu/tamu/sage/model/response/DiscoveryContext.java
@@ -5,31 +5,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.tamu.sage.model.DiscoveryView;
+import edu.tamu.sage.model.SearchField;
 
 public class DiscoveryContext implements Serializable {
 
     private static final long serialVersionUID = 6808155032067806535L;
-    
+
     private String name;
-    
+
     private String titleKey;
 
     private String uniqueIdentifierKey;
-    
+
     private String resourceThumbnailUriKey;
-    
+
     private String resourceLocationUriKey;
-    
+
     private Search search;
-    
+
     private List<Result> results;
-    
+
     private List<SortField> sortFields;
-    
+
+    private List<SearchField> searchFields;
+
     private List<SearchFilter> searchFilters;
-    
+
     private List<FacetFilter> facetFilters;
-    
+
     private String infoText;
 
     private String infoLinkText;
@@ -38,6 +41,7 @@ public class DiscoveryContext implements Serializable {
 
     public DiscoveryContext() {
         super();
+        searchFields = new  ArrayList<SearchField>();
         searchFilters = new  ArrayList<SearchFilter>();
         sortFields = new  ArrayList<SortField>();
     }
@@ -49,7 +53,7 @@ public class DiscoveryContext implements Serializable {
     public void setName(String name) {
         this.name = name;
     }
-    
+
     public String getTitleKey() {
         return titleKey;
     }
@@ -57,7 +61,7 @@ public class DiscoveryContext implements Serializable {
     public void setTitleKey(String titleKey) {
         this.titleKey = titleKey;
     }
-    
+
     public String getUniqueIdentifierKey() {
         return uniqueIdentifierKey;
     }
@@ -101,13 +105,21 @@ public class DiscoveryContext implements Serializable {
     public void setResults(List<Result> results) {
         this.results = results;
     }
-    
+
     public List<SortField> getSortFields() {
         return sortFields;
     }
 
     public void setSortFields(List<SortField> sortFields) {
         this.sortFields = sortFields;
+    }
+
+    public List<SearchField> getSearchFields() {
+        return searchFields;
+    }
+
+    public void setSearchFields(List<SearchField> searchFields) {
+        this.searchFields = searchFields;
     }
 
     public List<SearchFilter> getSearchFilters() {
@@ -152,7 +164,7 @@ public class DiscoveryContext implements Serializable {
 
     public static DiscoveryContext of(DiscoveryView dv) {
         DiscoveryContext dc = new DiscoveryContext();
-        
+
         dc.setName(dv.getName());
         dc.setTitleKey(dv.getTitleKey());
         dc.setUniqueIdentifierKey(dv.getUniqueIdentifierKey());
@@ -165,6 +177,7 @@ public class DiscoveryContext implements Serializable {
         SearchFilter defaultSearchFilter = new SearchFilter();
         defaultSearchFilter.setKey("all_fields");
         defaultSearchFilter.setLabel("All Fields");
+        dc.searchFields = dv.getSearchFields();
         dc.searchFilters.add(defaultSearchFilter);
 
 //        SearchFilter titleSearchFilter = new SearchFilter();
@@ -176,7 +189,7 @@ public class DiscoveryContext implements Serializable {
         identifierSortField.setKey(dc.getUniqueIdentifierKey());
         identifierSortField.setLabel("ID");
         dc.sortFields.add(identifierSortField);
-        
+
         dv.getResultMetadataFields().forEach(metadataField->{
             if(metadataField.isSearchable()) {
                 dc.searchFilters.add(SearchFilter.of(metadataField));
@@ -185,7 +198,7 @@ public class DiscoveryContext implements Serializable {
                 dc.sortFields.add(SortField.of(metadataField));
             }
         });
-        
+
         return dc;
     }
 }

--- a/src/main/java/edu/tamu/sage/model/response/Search.java
+++ b/src/main/java/edu/tamu/sage/model/response/Search.java
@@ -6,15 +6,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class Search {
 
-    private String query;
-    
-    private String sort;
-    
-    private long total;
+    private String field;
 
-    private int rows;
-    
-    private int start;
+    private long start;
+
+    private long total;
 
     @JsonIgnore
     private String solrQuery;
@@ -23,24 +19,9 @@ public class Search {
 
     public Search() {
         super();
-        rows = 10;
+        field = "";
         start = 0;
-    }
-
-    public String getQuery() {
-        return query;
-    }
-
-    public void setQuery(String query) {
-        this.query =  query;
-    }
-
-    public String getSort() {
-        return sort;
-    }
-
-    public void setSort(String sort) {
-        this.sort = sort;
+        total = 0;
     }
 
     public String getSolrQuery() {
@@ -50,29 +31,29 @@ public class Search {
     public void setSolrQuery(String solrQuery) {
         this.solrQuery = solrQuery;
     }
-    
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public void setStart(long start) {
+        this.start = start;
+    }
+
     public long getTotal() {
         return total;
     }
 
     public void setTotal(long total) {
         this.total = total;
-    }
-
-    public int getRows() {
-        return rows;
-    }
-
-    public void setRows(int rows) {
-        this.rows = rows;
-    }
-
-    public int getStart() {
-        return start;
-    }
-
-    public void setStart(int start) {
-        this.start = start;
     }
 
     public List<Filter> getFilters() {

--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -18,13 +18,12 @@ import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import edu.tamu.sage.exceptions.DiscoveryContextBuildException;
 import edu.tamu.sage.exceptions.SourceFieldsException;
 import edu.tamu.sage.model.DiscoveryView;
-import edu.tamu.sage.model.FacetFields;
-import edu.tamu.sage.model.MetadataField;
 import edu.tamu.sage.model.response.DiscoveryContext;
 import edu.tamu.sage.model.response.FacetFilter;
 import edu.tamu.sage.model.response.Filter;
@@ -52,119 +51,62 @@ public class SolrDiscoveryService {
         }
     }
 
-    public DiscoveryContext buildDiscoveryContext(DiscoveryView discoveryView, Map<String, String> filterMap, int rows, int start, String sort) throws DiscoveryContextBuildException, UnsupportedEncodingException {
-
+    public DiscoveryContext buildDiscoveryContext(DiscoveryView discoveryView, String field, String value, Pageable page, int offset, Map<String, String> filterMap) throws DiscoveryContextBuildException, UnsupportedEncodingException {
         DiscoveryContext discoveryContext = DiscoveryContext.of(discoveryView);
-
-        Search search = buildSearch(filterMap, discoveryView, rows, start, sort);
-
-        ResultSet resultSet = querySolrCore(discoveryView, search, sort);
-        List<Result> results = resultSet.results;
-        List<FacetFilter> facetFilter = resultSet.facetFilters;
-
-        discoveryContext.setResults(results);
-        discoveryContext.setSearch(search);
-        discoveryContext.setFacetFilters(facetFilter);
-
-        return discoveryContext;
-    }
-
-    private Search buildSearch(Map<String, String> filterMap, DiscoveryView discoveryView, int rows, int start, String sort) throws DiscoveryContextBuildException, UnsupportedEncodingException {
-
-        // TODO: REDO!!!
-
         Search search = new Search();
 
-        List<SolrField> availableFields = getAvailableFields(discoveryView);
+        search.setField(field.equalsIgnoreCase(ALL_FIELDS_KEY) ? "" : field);
 
+        String query = "*:*";
+        if (!(field.isEmpty() || value.isEmpty())) {
+            query = search.getField();
+            query += ":" + (value.isEmpty() ? "*" : value);
+        }
+
+        SolrQuery solrQuery = new SolrQuery(query);
+
+        // Only filter against designated facet fields.
         List<Filter> filters = new ArrayList<Filter>();
+        if (!discoveryView.getFacetFields().isEmpty()) {
+            discoveryView.getFacetFields().forEach(facetField -> {
+                solrQuery.addFacetField(facetField.getKey());
 
-        String query = "";
-        String solrQuery = "";
-
-        for (Map.Entry<String, String> entry : filterMap.entrySet()) {
-            String key = entry.getKey();
-            String vs = entry.getValue();
-
-            query += key + "=";
-            solrQuery += "(";
-
-            String[] values = vs.split(",");
-            for (int i = 0; i < values.length; i++) {
-
-                String label = key;
-
-                if (discoveryView.getTitleKey().equals(key)) {
-                    label = "Name";
-                } else if (ALL_FIELDS_KEY.equals(key)) {
-                    label = "All Fields";
-                } else {
-                    MetadataField m = discoveryView.findMetadataFieldByKey(key);
-                    if (m != null) {
-                        label = m.getLabel();
-                    } else {
-                        FacetFields ff = discoveryView.findFacetFieldByKey(key);
-                        label = ff != null ? ff.getLabel() : label;
-                    }
+                String filterKey = "f." + facetField.getKey();
+                if (filterMap.containsKey(filterKey)) {
+                    Filter filter = new Filter();
+                    filter.setKey(facetField.getKey());
+                    filter.setValue(filterMap.get(filterKey));
+                    filters.add(filter);
+                    solrQuery.addFilterQuery(facetField.getKey() + ":" + filterMap.get(filterKey));
                 }
+            });
 
-                filters.add(new Filter(key, label, values[i]));
-
-                if (key.equals(ALL_FIELDS_KEY)) {
-                    if (solrQuery.endsWith(" AND (")) {
-                        solrQuery = solrQuery.substring(0, solrQuery.length() - 6) + " OR (";
-                    }
-                    for (int j = 0; j < availableFields.size(); j++) {
-                        SolrField field = availableFields.get(j);
-                        if (!field.getName().equals(ALL_FIELDS_KEY)) {
-                            solrQuery += field.getName() + ":\"" + values[i] + "\"";
-                            if (j < availableFields.size()) {
-                                solrQuery += " OR ";
-                            }
-                        }
-                    }
-                } else {
-                    solrQuery += key + ":\"" + values[i] + "\"";
-                    if (i < values.length) {
-                        solrQuery += " OR ";
-                    }
-                }
-                query += values[i];
-                if (i < values.length - 1) {
-                    query += ",";
-                }
-            }
-
-            query += "&";
-            if (key.equals(ALL_FIELDS_KEY)) {
-                solrQuery = solrQuery.substring(0, solrQuery.length() - 4) + ")) OR ";
-            } else {
-                solrQuery = solrQuery.substring(0, solrQuery.length() - 4) + ") AND ";
-            }
+            solrQuery.setFacet(true);
+            solrQuery.setFacetLimit(Integer.MAX_VALUE);
         }
 
         search.setFilters(filters);
 
-        if (query.length() > 1) {
-            query = query.substring(0, query.length() - 1);
+        solrQuery.setRows(page.getPageSize());
+        solrQuery.setStart((page.getPageNumber() * page.getPageSize()) + offset);
+
+        if (page.getSort() != null) {
+            page.getSort().forEach(order->{
+                solrQuery.addSort(order.getProperty(), order.getDirection().isDescending() ? ORDER.desc : ORDER.asc);
+            });
         }
-        if (solrQuery.length() > 5) {
-            solrQuery = "(" + solrQuery.substring(0, solrQuery.length() - 5) + ")";
-        }
 
-        query += (query.length() > 0 ? "&" : "") + "start=" + start + "&rows=" + rows + "&sort=" + sort;
+        ResultSet resultSet = querySolrCore(discoveryView, solrQuery, search);
+        search.setStart((page.getPageNumber() * page.getPageSize()) + offset);
 
-        System.out.println("URL query: " + query);
-        System.out.println("Solr query: " + solrQuery);
+        List<Result> results = resultSet.results;
+        List<FacetFilter> facetFilter = resultSet.facetFilters;
 
-        search.setQuery(query);
-        search.setSolrQuery(solrQuery);
+        discoveryContext.setSearch(search);
+        discoveryContext.setResults(results);
+        discoveryContext.setFacetFilters(facetFilter);
 
-        search.setRows(rows);
-        search.setStart(start);
-        search.setSort(sort);
-
-        return search;
+        return discoveryContext;
     }
 
     public List<SolrField> getAvailableFields(DiscoveryView discoveryView) throws DiscoveryContextBuildException {
@@ -177,7 +119,30 @@ public class SolrDiscoveryService {
         }
     }
 
-    public ResultSet querySolrCore(DiscoveryView discoveryView, Search search, String sort) {
+    public SingleResultContext getSingleResult(DiscoveryView discoveryView, String resultId) throws DiscoveryContextBuildException {
+
+        SingleResultContext sinlgeResultContext = null;
+
+        try (SolrClient solr = new HttpSolrClient(discoveryView.getSource().getUri())) {
+            SolrQuery query = new SolrQuery();
+
+            query.setQuery(discoveryView.getUniqueIdentifierKey() + ":" + resultId);
+            query.setRows(1);
+
+            QueryResponse qr = solr.query(query);
+
+            if (qr.getResults().size() > 0) {
+                sinlgeResultContext = SingleResultContext.of(discoveryView, qr.getResults().get(0));
+            }
+
+        } catch (Exception e) {
+            throw new DiscoveryContextBuildException("Could not find singe result", e);
+        }
+
+        return sinlgeResultContext;
+    }
+
+    private ResultSet querySolrCore(DiscoveryView discoveryView, SolrQuery query, Search search) {
         logger.info("Using Discovery View: " + discoveryView.getName() + " to read from SOLR Core: " + discoveryView.getSource().getName() + " - " + discoveryView.getSource().getUri());
 
         List<Result> results = new ArrayList<Result>();
@@ -185,32 +150,10 @@ public class SolrDiscoveryService {
 
         SolrClient solr = new HttpSolrClient(discoveryView.getSource().getUri());
 
+        search.setTotal(0);
+
         try {
-
             solr.ping();
-
-            SolrQuery query = new SolrQuery();
-
-            query.setFacet(true);
-            query.setFacetLimit(Integer.MAX_VALUE);
-
-            discoveryView.getFacetFields().forEach(facetField -> {
-                query.addFacetField(facetField.getKey());
-            });
-
-            String q = discoveryView.getFilter();
-
-            if (search.getSolrQuery().length() > 0) {
-                q += " AND " + search.getSolrQuery();
-            }
-
-            query.setRows(search.getRows());
-
-            query.setStart(search.getStart());
-
-            query.setQuery(q);
-
-            query.addSort(sort, ORDER.asc);
 
             discoveryView.getResultMetadataFields().forEach(metadataField -> {
                 if (metadataField.getKey().contains("{{")) {
@@ -268,29 +211,6 @@ public class SolrDiscoveryService {
         }
 
         return new ResultSet(results, facetFilters);
-    }
-
-    public SingleResultContext getSinlgeResult(DiscoveryView discoveryView, String resultId) throws DiscoveryContextBuildException {
-
-        SingleResultContext sinlgeResultContext = null;
-
-        try (SolrClient solr = new HttpSolrClient(discoveryView.getSource().getUri())) {
-            SolrQuery query = new SolrQuery();
-
-            query.setQuery(discoveryView.getUniqueIdentifierKey() + ":" + resultId);
-            query.setRows(1);
-
-            QueryResponse qr = solr.query(query);
-
-            if (qr.getResults().size() > 0) {
-                sinlgeResultContext = SingleResultContext.of(discoveryView, qr.getResults().get(0));
-            }
-
-        } catch (Exception e) {
-            throw new DiscoveryContextBuildException("Could not find singe result", e);
-        }
-
-        return sinlgeResultContext;
     }
 
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -220,6 +220,7 @@
   <script src="model/resultModel.js"></script>
   <script src="model/fieldModel.js"></script>
   <script src="model/searchModel.js"></script>
+  <script src="model/searchFieldModel.js"></script>
 
   <!-- Components -->
   <script src="components/multiSuggestionInputComponent.js"></script>

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -162,7 +162,7 @@ var apiMapping = {
       'controller': 'operators',
       'httpMethod': 'GET',
       'method': ''
-    }, 
+    },
     types: {
       'endpoint': '/private/queue',
       'controller': 'operators',
@@ -317,6 +317,10 @@ var apiMapping = {
     lazy: true
   },
   Search: {
+    validations: false,
+    lazy: true
+  },
+  SearchField: {
     validations: false,
     lazy: true
   }

--- a/src/main/webapp/app/controllers/discoveryContextController.js
+++ b/src/main/webapp/app/controllers/discoveryContextController.js
@@ -10,9 +10,9 @@ sage.controller('DiscoveryContextController', function ($controller, $scope, $ro
 
   $scope.rowOptions = [];
 
-  var options = [10,25,50,100];
-  
-  for(var i in options) {
+  var options = [10, 25, 50, 100];
+
+  for (var i in options) {
     $scope.rowOptions.push({ value: options[i], label: options[i] + " Per Page"});
   }
 
@@ -22,14 +22,81 @@ sage.controller('DiscoveryContextController', function ($controller, $scope, $ro
 
   $scope.discoveryContext.ready().then(function() {
 
-    $scope.resetSearch = function() {
-      if($scope.discoveryContext.searchFilters) {
-        $scope.currentSearchFilter = $scope.discoveryContext.searchFilters[0];
-      } 
-      $scope.currentSearchValue = '';
+    $scope.resetSearch = function(useQueryParams) {
+      var i;
+
+      if (useQueryParams) {
+        if ($scope.discoveryContext.search.field === "") {
+          $location.search("field", null);
+        }
+
+        if ($scope.discoveryContext.search.value === "") {
+          $location.search("value", null);
+        }
+
+        if ($scope.discoveryContext.search.page.number === 0) {
+          $location.search("page", null);
+        }
+
+        if (angular.isDefined($scope.discoveryContext.sortFields)) {
+          if ($scope.discoveryContext.search.page.sort === $scope.discoveryContext.sortFields[0].key) {
+            $location.search("sort", null);
+          }
+        }
+
+        if (options.indexOf($scope.discoveryContext.search.page.size) === -1) {
+          $scope.discoveryContext.search.page.size = options[0];
+          $location.search("size", options[0]);
+        }
+
+        if ($scope.discoveryContext.search.page.offset === 0) {
+          $location.search("offset", null);
+        }
+
+        $scope.currentSearchField = "";
+        if (angular.isDefined($scope.discoveryContext.searchFields)) {
+          $scope.currentSearchField = $scope.discoveryContext.searchFields[0];
+
+          if (angular.isDefined($routeParams.field)) {
+            for (i = 0; i < $scope.discoveryContext.searchFields.length; i++) {
+              if ($scope.discoveryContext.searchFields[i].key === $routeParams.field) {
+                $scope.currentSearchField = $scope.discoveryContext.searchFields[i];
+                break;
+              }
+            }
+          }
+        }
+
+        $scope.currentSearchValue = "";
+        if (angular.isDefined($routeParams.value)) {
+          $scope.currentSearchValue = $routeParams.value;
+        } else if (angular.isDefined($scope.discoveryContext.search.value)) {
+          $scope.currentSearchValue = $scope.discoveryContext.search.value;
+        }
+      }
+      else {
+        $scope.currentSearchField = "";
+        if (angular.isDefined($scope.discoveryContext.searchFields)) {
+          $scope.currentSearchField = $scope.discoveryContext.searchFields[0];
+
+          if (angular.isDefined($scope.discoveryContext.search.field)) {
+            for (i = 0; i < $scope.discoveryContext.searchFields.length; i++) {
+              if ($scope.discoveryContext.searchFields[i].key === $scope.discoveryContext.search.field) {
+                $scope.currentSearchField = $scope.discoveryContext.searchFields[i];
+                break;
+              }
+            }
+          }
+        }
+
+        $scope.currentSearchValue = "";
+        if (angular.isDefined($scope.discoveryContext.search.value)) {
+          $scope.currentSearchValue = $scope.discoveryContext.search.value;
+        }
+      }
     };
 
-    $scope.resetSearch();
+    $scope.resetSearch(true);
 
     $scope.removeFilter = function(filter) {
       $scope.discoveryContext.removeFilter(filter).then(function() {
@@ -42,19 +109,50 @@ sage.controller('DiscoveryContextController', function ($controller, $scope, $ro
         $scope.resetSearch();
       });
     };
-    
+
+    $scope.updateLimit = function() {
+      if ($scope.discoveryContext.search.start > 0) {
+        var number = $scope.discoveryContext.search.start / $scope.discoveryContext.search.page.size;
+        $scope.discoveryContext.search.page.number = Math.floor(number);
+
+        if (number == $scope.discoveryContext.search.page.number) {
+          $scope.discoveryContext.search.page.offset = 0;
+        } else {
+          var offset = Math.abs($scope.discoveryContext.search.start - ($scope.discoveryContext.search.page.number * $scope.discoveryContext.search.page.size));
+          $scope.discoveryContext.search.page.offset = offset;
+        }
+
+        $location.search("page", $scope.discoveryContext.search.page.number);
+      }
+
+      $scope.discoveryContext.executeSearch(true).then(function() {
+        $scope.resetSearch();
+      });
+    };
+
+    $scope.updateSort = function() {
+      discoveryContext.executeSearch(true);
+    };
+
     $scope.searchProcessKeyPress = function($event) {
-      if(event.keyCode === 13 && $scope.currentSearchFilter) {
-        $scope.discoveryContext.addFilter($scope.currentSearchFilter.label, $scope.currentSearchFilter.key, $scope.currentSearchValue).then(function() {
+      if (event.keyCode === 13 && $scope.currentSearchField) {
+        $scope.discoveryContext.setSearchField($scope.currentSearchField.key, $scope.currentSearchValue);
+        $scope.discoveryContext.executeSearch().then(function() {
           $scope.resetSearch();
         });
       }
     };
 
     $scope.pageBack = function() {
-      if($scope.discoveryContext.search.start > 0) {
-        $scope.discoveryContext.search.start -= $scope.discoveryContext.search.rows;
-        $scope.discoveryContext.search.start = $scope.discoveryContext.search.start < 0 ? 0 : $scope.discoveryContext.search.start;
+      if ($scope.discoveryContext.search.start > 0) {
+        if ($scope.discoveryContext.search.page.number > 0) {
+          $scope.discoveryContext.search.page.number--;
+        }
+        else {
+          $scope.discoveryContext.search.page.offset = 0;
+          $location.search("offset", null);
+        }
+
         $scope.discoveryContext.executeSearch(true).then(function() {
           $scope.resetSearch();
         });
@@ -62,15 +160,13 @@ sage.controller('DiscoveryContextController', function ($controller, $scope, $ro
     };
 
     $scope.pageForward = function() {
-      if($scope.discoveryContext.search.start < $scope.discoveryContext.search.total - $scope.discoveryContext.search.rows) {
-        $scope.discoveryContext.search.start += $scope.discoveryContext.search.rows;
-        $scope.discoveryContext.search.start = $scope.discoveryContext.search.start > $scope.discoveryContext.search.total ? $scope.discoveryContext.search.total : $scope.discoveryContext.search.start;
+      if ($scope.discoveryContext.search.start < $scope.discoveryContext.search.total - $scope.discoveryContext.search.page.size) {
+        $scope.discoveryContext.search.page.number++;
         $scope.discoveryContext.executeSearch(true).then(function() {
           $scope.resetSearch();
         });
       }
     };
-
   });
 
 });

--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -1,4 +1,4 @@
-sage.controller('DiscoveryViewManagementController', function ($controller, $scope, NgTableParams, DiscoveryViewRepo, SourceRepo) {
+sage.controller('DiscoveryViewManagementController', function ($controller, $scope, NgTableParams, DiscoveryViewRepo, SearchField, SourceRepo) {
 
   angular.extend(this, $controller('AbstractController', {
       $scope: $scope
@@ -40,7 +40,9 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
       dv.searchFields = [];
     }
 
-    dv.searchFields.push(DiscoveryViewRepo.scaffoldSearchField);
+    var searchField = new SearchField();
+    angular.extend(searchField, DiscoveryViewRepo.scaffoldSearchField);
+    dv.searchFields.push(searchField);
   };
 
   $scope.startCreateDiscoveryView = function() {

--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -9,10 +9,8 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
   $scope.metadataFields = [];
 
   $scope.discoveryViewToCreate = DiscoveryViewRepo.getScaffold();
-  $scope.newDiscoveryViewMappings = {};
   $scope.discoveryViewToUpdate = {};
   $scope.discoveryViewToDelete = {};
-
 
   $scope.discoveryViewForms = {
     validations: DiscoveryViewRepo.getValidations(),
@@ -27,6 +25,14 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
       }
     }
     $scope.closeModal();
+  };
+
+  $scope.appendSearchFieldItem = function() {
+    if (!angular.isDefined($scope.discoveryViewToUpdate.searchFields)) {
+      $scope.discoveryViewToUpdate.searchFields = [];
+    }
+
+    $scope.discoveryViewToUpdate.searchFields.push(DiscoveryViewRepo.scaffoldSearchField);
   };
 
   $scope.startCreateDiscoveryView = function() {
@@ -47,27 +53,33 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
     $scope.resetDiscoveryViewForms();
   };
 
-  $scope.createDiscoveryViewGeneralIsInvalid = function() {
+  $scope.isDiscoveryViewGeneralInvalid = function(key) {
+    var name = $scope.discoveryViewForms[key].name;
+    var source = $scope.discoveryViewForms[key].source;
+    var filter = $scope.discoveryViewForms[key].filter;
+    var slug = $scope.discoveryViewForms[key].slug;
 
-    var createName = $scope.discoveryViewForms.create.name;
-    var createSource = $scope.discoveryViewForms.create.source;
-    var createFilter = $scope.discoveryViewForms.create.filter;
-    var createSlug = $scope.discoveryViewForms.create.slug;
-
-    return  (createName && createName.$invalid) ||
-            (createSource && createSource.$invalid) ||
-            (createFilter && createFilter.$invalid) ||
-            (createSlug && createSlug.$invalid);
+    return (name && name.$invalid) ||
+           (source && source.$invalid) ||
+           (filter && filter.$invalid) ||
+           (slug && slug.$invalid);
   };
 
-  $scope.createDiscoveryViewResultsIsInvalid = function() {
+  $scope.isDiscoveryViewResultsInvalid = function(key) {
+    var primaryKey = $scope.discoveryViewForms[key].primaryKey;
+    var primaryURI = $scope.discoveryViewForms[key].primaryURIKey;
 
-    var createPrimaryKey = $scope.discoveryViewForms.create.primaryKey;
-    var createPrimaryURI = $scope.discoveryViewForms.create.primaryURIKey;
+    return (primaryKey && primaryKey.$invalid) ||
+           (primaryURI && primaryURI.$invalid);
+  };
 
-    return  (createPrimaryKey && createPrimaryKey.$invalid) ||
-            (createPrimaryURI && createPrimaryURI.$invalid);
-            
+  $scope.isDiscoveryViewFacetsInvalid = function(key) {
+    return false;
+  };
+
+  $scope.isDiscoveryViewSearchInvalid = function(key) {
+    var searchFields = $scope.discoveryViewToUpdate.searchFields;
+    return (searchFields && (searchFields.$invalid || searchFields.length == 0));
   };
 
   $scope.updateDiscoveryView = function() {
@@ -81,20 +93,21 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
 
   $scope.startUpdateDiscoveryView = function(dv) {
     $scope.discoveryViewToUpdate = dv;
+    $scope.getFields(dv);
     $scope.openModal("#updateDiscoveryViewModal");
   };
 
-  $scope.cancelUpdateDiscoveryView = function(reader) {
+  $scope.cancelUpdateDiscoveryView = function() {
     $scope.discoveryViewToUpdate = {};
     $scope.resetDiscoveryViewForms();
   };
 
-  $scope.confirmDeleteDiscoveryView = function(reader) {
-    $scope.discoveryViewToDelete = reader;
+  $scope.confirmDeleteDiscoveryView = function(dv) {
+    $scope.discoveryViewToDelete = dv;
     $scope.openModal("#confirmDeleteDiscoveryViewModal");
   };
 
-  $scope.cancelDeleteDiscoveryView = function(reader) {
+  $scope.cancelDeleteDiscoveryView = function() {
     $scope.discoveryViewToDelete = {};
     $scope.resetDiscoveryViewForms();
   };
@@ -107,8 +120,10 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
     });
   };
 
-  $scope.getFields = function(discoveryView) {
-    $scope.fields = SourceRepo.getAvailableFields(discoveryView.source.uri, discoveryView.filter);
+  $scope.getFields = function(dv) {
+    if (angular.isDefined(dv)) {
+      $scope.fields = SourceRepo.getAvailableFields(dv.source.uri, dv.filter);
+    }
   };
 
   $scope.findFieldByKey = function(key) {

--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -27,12 +27,20 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
     $scope.closeModal();
   };
 
-  $scope.appendSearchFieldItem = function() {
-    if (!angular.isDefined($scope.discoveryViewToUpdate.searchFields)) {
-      $scope.discoveryViewToUpdate.searchFields = [];
+  $scope.appendFacetFieldItem = function(dv) {
+    if (!angular.isDefined(dv.facetFields)) {
+      dv.facetFields = [];
     }
 
-    $scope.discoveryViewToUpdate.searchFields.push(DiscoveryViewRepo.scaffoldSearchField);
+    dv.facetFields.push({});
+  };
+
+  $scope.appendSearchFieldItem = function(dv) {
+    if (!angular.isDefined(dv.searchFields)) {
+      dv.searchFields = [];
+    }
+
+    dv.searchFields.push(DiscoveryViewRepo.scaffoldSearchField);
   };
 
   $scope.startCreateDiscoveryView = function() {

--- a/src/main/webapp/app/model/discoveryContextModel.js
+++ b/src/main/webapp/app/model/discoveryContextModel.js
@@ -3,53 +3,61 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
 
     var discoveryContext = this;
     var searching;
+    var defaultPageSize = 10;
+    var defaultPageSort = "id"; // @fixme: needs to be determined from DiscoveryView.
 
     var fetchContext = function () {
-
-      var q = {};
-
-      angular.forEach(discoveryContext.search.filters, function(filter) {
-        if(!q[filter.key]) {
-          q[filter.key] = [];  
-        }
-        q[filter.key].push(filter.value);
-      });
-
-      var rows = $routeParams.rows ? $routeParams.rows : 10;
-      var start = $routeParams.start ? $routeParams.start : 0;
-      var sort = $routeParams.sort ? $routeParams.sort : "id";
-
-      q.rows = discoveryContext.search.rows !== undefined ? discoveryContext.search.rows : rows;
-      q.start = discoveryContext.search.start !== undefined ? discoveryContext.search.start : start;
-      q.sort = discoveryContext.search.sort !== undefined ? discoveryContext.search.sort : sort;
-      
-      return WsApi.fetch(discoveryContext.getMapping().load, {
+      var parameters = {
         pathValues: {
           slug: discoveryContext.slug
         },
-        query: q
+        query: {
+          field: angular.isDefined(discoveryContext.search.field) ? discoveryContext.search.field : "",
+          value: angular.isDefined(discoveryContext.search.value) ? discoveryContext.search.value : "",
+          sort: angular.isDefined(discoveryContext.search.page.sort) ? discoveryContext.search.page.sort : defaultPageSort,
+          page: angular.isDefined(discoveryContext.search.page.number) ? discoveryContext.search.page.number : 0,
+          size: angular.isDefined(discoveryContext.search.page.size) ? discoveryContext.search.page.size : defaultPageSize,
+          offset: angular.isDefined(discoveryContext.search.page.offset) ? discoveryContext.search.page.offset : 0
+        }
+      };
+
+      angular.forEach(discoveryContext.search.filters, function(filter) {
+        var filterKey = "f." + filter.key;
+        if (!angular.isDefined(parameters.query[filterKey])) {
+          parameters.query[filterKey] = [];
+        }
+        parameters.query[filterKey].push(filter.value);
       });
+
+      return WsApi.fetch(discoveryContext.getMapping().load, parameters);
     };
 
     var populateProperty = function(pname, ctor) {
-      for(var i in discoveryContext[pname]) {
+      for (var i in discoveryContext[pname]) {
         discoveryContext[pname][i] = new ctor(discoveryContext[pname][i]);
       }
     };
 
     discoveryContext.before(function () {
-
       var filters = [];
-      angular.forEach($location.search(), function(v,k) {
-        var filter = {
-          key: k,
-          value: v
-        };
-        filters.push(filter);
-      });
+
+      if ($routeParams.filters) {
+        angular.forEach($routeParams.filters, function(v, k) {
+          var filter = {
+            key: k,
+            value: v
+          };
+          filters.push(filter);
+        });
+      }
+
       discoveryContext.search = new Search({
+        field: angular.isDefined($routeParams.field) ? $routeParams.field : "",
+        value: angular.isDefined($routeParams.value) ? $routeParams.value : "",
         filters: filters,
-        query: $location.search()
+        start: 0,
+        total: 0,
+        page: discoveryContext.buildPage()
       });
 
       return discoveryContext.reload();
@@ -57,18 +65,37 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
 
     discoveryContext.reload = function() {
       var defer = $q.defer();
-      fetchContext().then(function (res) {
-        var dc = angular.fromJson(res.body).payload.DiscoveryContext;
 
-        angular.extend(discoveryContext, dc);
+      fetchContext().then(function (res) {
+        var payload = angular.fromJson(res.body).payload.DiscoveryContext;
+        var search = payload.search;
+
+        // do not override local search settings, only these search properties are needed.
+        var page = Number(search.page);
+        if (!isNaN(page)) {
+          discoveryContext.search.page.number = page;
+          $location.search("page", discoveryContext.search.page.number);
+        }
+        discoveryContext.search.field = search.field;
+        discoveryContext.search.filters = search.filters ? search.filters : [];
+        discoveryContext.search.start = search.start;
+        discoveryContext.search.total = search.total;
+        delete payload.search;
+
+        angular.extend(discoveryContext, payload);
 
         populateProperty("results", Result);
-
         populateProperty("fields", Field);
 
         defer.resolve(discoveryContext);
       });
+
       return defer.promise;
+    };
+
+    discoveryContext.setSearchField = function(key, value) {
+      discoveryContext.search.field = key;
+      discoveryContext.search.value = value;
     };
 
     discoveryContext.addFilter = function(label, key, value) {
@@ -77,36 +104,56 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
         key: key,
         value: value
       };
+
+      if (!discoveryContext.search.filters) {
+        discoveryContext.search.filters = [];
+      }
+
       discoveryContext.search.filters.push(filter);
-      return discoveryContext.executeSearch();
+      return discoveryContext.executeSearch(true);
     };
 
     discoveryContext.removeFilter = function(filter) {
-      for(var i = 0; i < discoveryContext.search.filters.length; i++) {
+      for (var i = 0; i < discoveryContext.search.filters.length; i++) {
         var f = discoveryContext.search.filters[i];
-        if(f.key === filter.key && f.value === filter.value) {
+        if (f.key === filter.key && f.value === filter.value) {
           discoveryContext.search.filters.splice(i, 1);
         }
       }
-      return discoveryContext.executeSearch();
+      return discoveryContext.executeSearch(true);
     };
 
     discoveryContext.clearFilters = function() {
       discoveryContext.search.filters.length = 0;
-      return discoveryContext.executeSearch();
+      return discoveryContext.executeSearch(true);
     };
 
     discoveryContext.executeSearch = function(maintainPage) {
       return $q(function(resolve) {
-        if(!searching) {
+        if (!searching) {
           searching = true;
-          if(!maintainPage) {
+
+          if (!maintainPage) {
             discoveryContext.search.start = 0;
-            $location.search("start", 0);
+            discoveryContext.search.total = 0;
+            discoveryContext.search.page.number = 0;
+            $location.search("field", null);
+            $location.search("value", null);
+            $location.search("page", null);
+            $location.search("sort", null);
+            $location.search("size", null);
+            $location.search("offset", null);
+            $location.search("filters", null);
           }
+
           discoveryContext.reload().then(function() {
             searching = false;
-            $location.search(discoveryContext.search.query);
+            $location.search("field", discoveryContext.search.field === "" ? null : discoveryContext.search.field);
+            $location.search("value", discoveryContext.search.value === "" ? null : discoveryContext.search.value);
+            $location.search("page", discoveryContext.search.page.number === 0 ? null : discoveryContext.search.page.number);
+            $location.search("sort", discoveryContext.search.page.sort === defaultPageSort ? null : discoveryContext.search.page.sort);
+            $location.search("size", discoveryContext.search.page.size === defaultPageSize ? null : discoveryContext.search.page.size);
+            $location.search("offset", discoveryContext.search.page.offset === 0 ? null : discoveryContext.search.page.offset);
             resolve();
           });
         } else {
@@ -119,7 +166,43 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
       return searching;
     };
 
-    return this;
+    discoveryContext.buildPage = function() {
+      var page = {
+        number: 0,
+        size: defaultPageSize,
+        sort: defaultPageSort,
+        offset: 0
+      };
+      var number;
 
+      if ($routeParams.page) {
+        number = Number($routeParams.page);
+        if (!isNaN(number)) {
+          page.number = number;
+        }
+      }
+
+      if ($routeParams.size) {
+        number = Number($routeParams.size);
+        if (!isNaN(number)) {
+          page.size = number;
+        }
+      }
+
+      if ($routeParams.offset) {
+        number = Number($routeParams.offset);
+        if (!isNaN(number)) {
+          page.offset = number;
+        }
+      }
+
+      if ($routeParams.sort) {
+        page.sort = $routeParams.sort;
+      }
+
+      return page;
+    };
+
+    return this;
   };
 });

--- a/src/main/webapp/app/model/searchFieldModel.js
+++ b/src/main/webapp/app/model/searchFieldModel.js
@@ -1,0 +1,7 @@
+sage.model("SearchField", function () {
+  return function SearchField() {
+    var searchField = this;
+
+    return searchField;
+  };
+});

--- a/src/main/webapp/app/repo/discoveryViewRepo.js
+++ b/src/main/webapp/app/repo/discoveryViewRepo.js
@@ -1,7 +1,7 @@
-sage.repo("DiscoveryViewRepo", function(DiscoveryView, SearchField) {
+sage.repo("DiscoveryViewRepo", function() {
   var discoveryViewRepo = this;
 
-  discoveryViewRepo.scaffold = new DiscoveryView({
+  discoveryViewRepo.scaffold = {
     name: "",
     source: "",
     facetFields: [],
@@ -9,22 +9,22 @@ sage.repo("DiscoveryViewRepo", function(DiscoveryView, SearchField) {
     resourceLocationUriKey: "",
     resourceThumbnailUriKey: "",
     resultMetadataFields: [],
-    searchFields: [ new SearchField({
+    searchFields: [ {
       key: "all_fields",
       label: "Everything"
-    })],
+    }],
     slug: "",
     titleKey: "",
     infoLinkText: "",
     infoLinkUrl: "",
     infoText: "",
     uniqueIdentifierKey: ""
-  });
+  };
 
-  discoveryViewRepo.scaffoldSearchField = new SearchField({
+  discoveryViewRepo.scaffoldSearchField = {
     key: "",
     label: ""
-  });
+  };
 
   return discoveryViewRepo;
 });

--- a/src/main/webapp/app/repo/discoveryViewRepo.js
+++ b/src/main/webapp/app/repo/discoveryViewRepo.js
@@ -1,4 +1,4 @@
-sage.repo("DiscoveryViewRepo", function(DiscoveryView) {
+sage.repo("DiscoveryViewRepo", function(DiscoveryView, SearchField) {
   var discoveryViewRepo = this;
 
   discoveryViewRepo.scaffold = new DiscoveryView({
@@ -9,12 +9,21 @@ sage.repo("DiscoveryViewRepo", function(DiscoveryView) {
     resourceLocationUriKey: "",
     resourceThumbnailUriKey: "",
     resultMetadataFields: [],
+    searchFields: [ new SearchField({
+      key: "all_fields",
+      label: "Everything"
+    })],
     slug: "",
     titleKey: "",
     infoLinkText: "",
     infoLinkUrl: "",
     infoText: "",
     uniqueIdentifierKey: ""
+  });
+
+  discoveryViewRepo.scaffoldSearchField = new SearchField({
+    key: "",
+    label: ""
   });
 
   return discoveryViewRepo;

--- a/src/main/webapp/app/views/discovery/discovery-context.html
+++ b/src/main/webapp/app/views/discovery/discovery-context.html
@@ -25,7 +25,7 @@
             <form class="form-group">
             <div class="input-group">
                 <div class="input-group-btn">
-                  <select class="form-control dc-filter-select" ng-model="currentSearchFilter" ng-options="filter.label for filter in discoveryContext.searchFilters"></select>
+                  <select class="form-control dc-filter-select" ng-model="currentSearchField" ng-options="searchField.label for searchField in discoveryContext.searchFields"></select>
                 </div>
                 <input type="text" class="form-control dc-search-input" ng-model="currentSearchValue" ng-keypress="searchProcessKeyPress($event)">
             </div>
@@ -41,23 +41,23 @@
           </ul>
         </div>
       </div>
-    
+
       <div class="row dc-paging-controls-top">
         <div class="col-md-6 col-sm-4">
           <ul class="list-inline paging-controls">
-            <li class="list-inline-item" ng-click="pageBack()"><span ng-class="{'link-like': discoveryContext.search.start>0}"><span class="glyphicon glyphicon-chevron-left"></span>Previouse</span></li>
-            <li class="list-inline-item"><strong>{{discoveryContext.search.start + 1}}</strong>-<strong>{{discoveryContext.search.start + discoveryContext.search.rows > discoveryContext.search.total ? discoveryContext.search.total : discoveryContext.search.start + discoveryContext.search.rows}}</strong> of <strong>{{discoveryContext.search.total}}</strong></li>
-            <li class="list-inline-item" ng-click="pageForward()"><span ng-class="{'link-like': discoveryContext.search.start<discoveryContext.search.total-discoveryContext.search.rows}">Next<span class="glyphicon glyphicon-chevron-right"></span></span></li>
+            <li class="list-inline-item" ng-click="pageBack()"><span ng-class="{ 'link-like': discoveryContext.search.start > 0 }"><span class="glyphicon glyphicon-chevron-left"></span>Previous</span></li>
+            <li class="list-inline-item"><strong>{{ discoveryContext.search.total == 0 ? 0 : discoveryContext.search.start + 1 }}</strong>-<strong>{{ discoveryContext.search.start + discoveryContext.search.page.size > discoveryContext.search.total ? discoveryContext.search.total : discoveryContext.search.start + discoveryContext.search.page.size }}</strong> of <strong>{{discoveryContext.search.total}}</strong></li>
+            <li class="list-inline-item" ng-click="pageForward()"><span ng-class="{ 'link-like': discoveryContext.search.start < discoveryContext.search.total - discoveryContext.search.page.size }">Next<span class="glyphicon glyphicon-chevron-right"></span></span></li>
           </ul>
         </div>
         <div class="col-sm-4 col-md-3">
-          <select class="form-control dc-filter-select" ng-model="discoveryContext.search.sort" ng-options="sort.key as sort.label for sort in discoveryContext.sortFields" ng-change="discoveryContext.executeSearch(true)"></select>
+          <select class="form-control dc-filter-select" ng-model="discoveryContext.search.page.sort" ng-options="sort.key as sort.label for sort in discoveryContext.sortFields" ng-change="updateSort()"></select>
         </div>
         <div class="col-sm-4 col-md-3">
-          <select class="form-control dc-filter-select" ng-model="discoveryContext.search.rows" ng-options="rows.value as rows.label for rows in rowOptions" ng-change="discoveryContext.executeSearch(true)"></select>
+          <select class="form-control dc-filter-select" ng-model="discoveryContext.search.page.size" ng-options="rows.value as rows.label for rows in rowOptions" ng-change="updateLimit()"></select>
         </div>
       </div>
-    
+
       <hr class="dc-results-hr" />
 
       <div class="row dc-results">
@@ -81,6 +81,5 @@
         </div>
       </div>
     </div>
-  </div>  
+  </div>
 </div>
-  

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -4,7 +4,6 @@
     <h4 class="modal-title">Create Discovery View</h4>
   </div>
   <div class="modal-body">
-
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">
@@ -13,6 +12,7 @@
           <div class="col-sm-10 col-sm-offset-1">
             <br>
             <validatedinput
+              id="createName"
               model="discoveryViewToCreate"
               property="name"
               label="Name"
@@ -22,8 +22,9 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedselect
+              id="createSource"
               model="discoveryViewToCreate"
               property="source"
               options="sources"
@@ -33,10 +34,12 @@
               form="discoveryViewForms.create"
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
-              autocomplete="off">
+              autocomplete="off"
+              change="getFields(discoveryViewToCreate)">
             </validatedselect>
-    
+
             <validatedinput
+              id="createFilter"
               model="discoveryViewToCreate"
               property="filter"
               label="Filter"
@@ -46,8 +49,9 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedinput
+              id="createSlug"
               model="discoveryViewToCreate"
               property="slug"
               label="Slug"
@@ -59,6 +63,7 @@
             </validatedinput>
 
             <validatedinput
+              id="createInfoLinkText"
               model="discoveryViewToCreate"
               property="infoLinkText"
               label="Info Link Text"
@@ -70,6 +75,7 @@
             </validatedinput>
 
             <validatedinput
+              id="createInfoLinkUrl"
               model="discoveryViewToCreate"
               property="infoLinkUrl"
               label="Info Link Url"
@@ -81,12 +87,13 @@
             </validatedinput>
 
             <validatedtextarea
+              property="idInfoText"
               model="discoveryViewToCreate"
               property="infoText"
               label="Info Text"
               form="discoveryViewForms.create"
               validations="discoveryViewForms.validations"
-              results="discoveryViewForms.getResults()"> 
+              results="discoveryViewForms.getResults()">
             </validatedtextarea>
 
           </div>
@@ -103,6 +110,7 @@
           <div class="row">
             <div class="col-sm-5 col-sm-offset-1">
               <validatedselect
+                id="createUniqueIdentifierKey"
                 model="discoveryViewToCreate"
                 property="uniqueIdentifierKey"
                 options="fields"
@@ -116,12 +124,13 @@
               </validatedselect>
             </div>
             <div class="col-sm-5">
-              <multi-suggestion-input 
+              <multi-suggestion-input
+                id="createTitleKey"
                 model="discoveryViewToCreate"
                 property="titleKey"
                 optionproperty="name"
                 suggestions="fields"
-                name="titleKey"                
+                name="titleKey"
                 label="Title Key"
                 placeholder="'{{' to see Title Key suggesions">
               </multi-suggestion-input>
@@ -129,23 +138,25 @@
           </div>
           <div class="row">
               <div class="col-sm-5 col-sm-offset-1">
-                <multi-suggestion-input 
+                <multi-suggestion-input
+                  id="createResourceThumbnailUriKey"
                   model="discoveryViewToCreate"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceThumbnailUriKey"                
+                  name="resourceThumbnailUriKey"
                   label="Thumbnail Uri Key"
                   placeholder="'{{' to see Thumbnail Uri Key suggesions">
                 </multi-suggestion-input>
               </div>
               <div class="col-sm-5">
-                <multi-suggestion-input 
+                <multi-suggestion-input
+                  id="createDiscoveryViewToCreate"
                   model="discoveryViewToCreate"
                   property="resourceLocationUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceUriKey"                
+                  name="resourceUriKey"
                   label="Resource Key"
                   placeholder="'{{' to see Resource Key suggesions">
                 </multi-suggestion-input>
@@ -153,7 +164,7 @@
             </div>
         </div>
         <hr>
-        <div class="row" ng-init="discoveryViewToCreate.resultMetadataFields=[]">
+        <div class="row">
           <div class="row">
             <div class="col-sm-offset-1 co-xs-12">
               <h4>Result Metadata</h4>
@@ -260,7 +271,7 @@
         </div>
       </uib-tab>
       <uib-tab index="2" heading="Facets" disable="true">
-        <div class="row" ng-init="discoveryViewToCreate.facetFields=[]">
+        <div class="row">
           <div class="row">
             <div class="col-sm-offset-1 co-xs-12">
               <h4>Facet Fields</h4>
@@ -294,7 +305,7 @@
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="resultMetadataField in discoveryViewToCreate.facetFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="facetField in discoveryViewToCreate.facetFields track by $index" ng-hide="$first">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -324,16 +335,63 @@
           </div>
         </div>
       </uib-tab>
+      <uib-tab index="3" heading="Search" disable="true">
+        <div class="row">
+          <div class="row">
+            <div class="col-sm-offset-1 co-xs-12">
+              <h4>Search Fields</h4>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-2 col-sm-offset-1">
+              <div class="form-group">
+                <label for="key">Key</label>
+                <select name="key" class="form-control" ng-model="discoveryViewToCreate.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
+              </div>
+            </div>
+            <div class="col-xs-7">
+              <div class="form-group">
+                <label for="name">Label</label>
+                <input name="name" placeholder="Display name of search" type="text" class="form-control" ng-model="discoveryViewToCreate.searchFields[0].label">
+              </div>
+            </div>
+            <div class="col-xs-2">
+              <div class="form-group add-field-group">
+                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem()"><span class="glyphicon glyphicon-plus"></span></button>
+              </div>
+            </div>
+          </div>
+          <div class="row" ng-repeat="searchField in discoveryViewToCreate.searchFields track by $index" ng-hide="$first">
+            <div class="col-xs-2 col-sm-offset-1">
+              <div class="form-group">
+                <label for="key">Key</label>
+                <select name="key" class="form-control" ng-model="discoveryViewToCreate.searchFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
+              </div>
+            </div>
+            <div class="col-xs-7">
+              <div class="form-group">
+                <label for="label">Label</label>
+                <input name="label" placeholder="Display label of search" type="text" class="form-control" ng-model="discoveryViewToCreate.searchFields[$index].label">
+              </div>
+            </div>
+            <div class="col-xs-2">
+              <div class="form-group add-field-group">
+                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToCreate.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </uib-tab>
     </uib-tabset>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelCreateDiscoveryView()">Cancel</button>
-
-
-    <button ng-show="activeJustified == 0" ng-disabled="createDiscoveryViewGeneralIsInvalid()" type="button" class="btn btn-success" ng-click="activeJustified = 1; getFields(discoveryViewToCreate);">Next</button>
+    <button ng-show="activeJustified == 0" ng-disabled="isDiscoveryViewGeneralInvalid('create')" type="button" class="btn btn-success" ng-click="activeJustified = 1; getFields(discoveryViewToCreate)">Next</button>
     <button ng-show="activeJustified == 1" type="button" class="btn btn-success" ng-click="activeJustified = 0">Back</button>
-    <button ng-show="activeJustified == 1" ng-disabled="createDiscoveryViewResultsIsInvalid()" type="button" class="btn btn-success" ng-click="activeJustified = 2">Next</button>
+    <button ng-show="activeJustified == 1" ng-disabled="isDiscoveryViewResultsInvalid('create')" type="button" class="btn btn-success" ng-click="activeJustified = 2;">Next</button>
     <button ng-show="activeJustified == 2" type="button" class="btn btn-success" ng-click="activeJustified = 1">Back</button>
-    <button ng-show="activeJustified == 2" ng-disabled="discoveryViewForms.create.$invalid" type="submit" class="btn btn-success">Create</button>
+    <button ng-show="activeJustified == 2" ng-disabled="isDiscoveryViewFacetsInvalid('create')" type="button" class="btn btn-success" ng-click="activeJustified = 3;">Next</button>
+    <button ng-show="activeJustified == 3" type="button" class="btn btn-success" ng-click="activeJustified = 2">Back</button>
+    <button ng-show="activeJustified == 3" ng-disabled="isDiscoveryViewSearchInvalid('create') || discoveryViewForms.create.$invalid" type="submit" class="btn btn-success">Create</button>
   </div>
 </form>

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -301,7 +301,7 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="discoveryViewToCreate.facetFields.push({})"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryViewToCreate)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
@@ -357,7 +357,7 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem()"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryViewToCreate)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -4,7 +4,6 @@
     <h4 class="modal-title">Edit Discovery View</h4>
   </div>
   <div class="modal-body">
-
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">
@@ -13,6 +12,7 @@
           <div class="col-sm-10 col-sm-offset-1">
             <br>
             <validatedinput
+              id="updateName"
               model="discoveryViewToUpdate"
               property="name"
               label="Name"
@@ -22,8 +22,9 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedselect
+              id="updateSource"
               model="discoveryViewToUpdate"
               property="source"
               options="sources"
@@ -33,10 +34,12 @@
               form="discoveryViewForms.update"
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
-              autocomplete="off">
+              autocomplete="off"
+              change="getFields(discoveryViewToUpdate)">
             </validatedselect>
-    
+
             <validatedinput
+              id="updateFilter"
               model="discoveryViewToUpdate"
               property="filter"
               label="Filter"
@@ -46,8 +49,9 @@
               results="discoveryViewForms.getResults()"
               autocomplete="off">
             </validatedinput>
-    
+
             <validatedinput
+              id="updateSlug"
               model="discoveryViewToUpdate"
               property="slug"
               label="Slug"
@@ -59,6 +63,7 @@
             </validatedinput>
 
             <validatedinput
+              id="updateInfoLinkText"
               model="discoveryViewToUpdate"
               property="infoLinkText"
               label="Info Link Text"
@@ -70,6 +75,7 @@
             </validatedinput>
 
             <validatedinput
+              id="updateInfoLinkUrl"
               model="discoveryViewToUpdate"
               property="infoLinkUrl"
               label="Info Link Url"
@@ -81,12 +87,13 @@
             </validatedinput>
 
             <validatedtextarea
+              id="updateInfoText"
               model="discoveryViewToUpdate"
               property="infoText"
               label="Info Text"
               form="discoveryViewForms.update"
               validations="discoveryViewForms.validations"
-              results="discoveryViewForms.getResults()"> 
+              results="discoveryViewForms.getResults()">
             </validatedtextarea>
 
           </div>
@@ -103,6 +110,7 @@
           <div class="row">
             <div class="col-sm-5 col-sm-offset-1">
               <validatedselect
+                id="updateUniqueIdentifierKey"
                 model="discoveryViewToUpdate"
                 property="uniqueIdentifierKey"
                 options="fields"
@@ -116,12 +124,13 @@
               </validatedselect>
             </div>
             <div class="col-sm-5">
-              <multi-suggestion-input 
+              <multi-suggestion-input
+                id="updateTitleKey"
                 model="discoveryViewToUpdate"
                 property="titleKey"
                 optionproperty="name"
                 suggestions="fields"
-                name="titleKey"                
+                name="titleKey"
                 label="Title Key"
                 placeholder="'{{' to see Title Key suggesions">
               </multi-suggestion-input>
@@ -129,23 +138,25 @@
           </div>
           <div class="row">
               <div class="col-sm-5 col-sm-offset-1">
-                <multi-suggestion-input 
+                <multi-suggestion-input
+                  id="updateResourceThumbnailUriKey"
                   model="discoveryViewToUpdate"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceThumbnailUriKey"                
+                  name="resourceThumbnailUriKey"
                   label="Thumbnail Uri Key"
                   placeholder="'{{' to see Thumbnail Uri Key suggesions">
                 </multi-suggestion-input>
               </div>
               <div class="col-sm-5">
-                <multi-suggestion-input 
+                <multi-suggestion-input
+                  id="updateResourceLocationUriKey"
                   model="discoveryViewToUpdate"
                   property="resourceLocationUriKey"
                   optionproperty="name"
                   suggestions="fields"
-                  name="resourceUriKey"                
+                  name="resourceUriKey"
                   label="Resource Key"
                   placeholder="'{{' to see Resource Key suggesions">
                 </multi-suggestion-input>
@@ -153,7 +164,7 @@
             </div>
         </div>
         <hr>
-        <div class="row" ng-init="discoveryViewToUpdate.resultMetadataFields=[]">
+        <div class="row">
           <div class="row">
             <div class="col-sm-offset-1 co-xs-12">
               <h4>Result Metadata</h4>
@@ -260,7 +271,7 @@
         </div>
       </uib-tab>
       <uib-tab index="2" heading="Facets" disable="true">
-        <div class="row" ng-init="discoveryViewToUpdate.facetFields=[]">
+        <div class="row">
           <div class="row">
             <div class="col-sm-offset-1 co-xs-12">
               <h4>Facet Fields</h4>
@@ -294,7 +305,7 @@
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="resultMetadataField in discoveryViewToUpdate.facetFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="facetField in discoveryViewToUpdate.facetFields track by $index" ng-hide="$first">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -324,16 +335,63 @@
           </div>
         </div>
       </uib-tab>
+      <uib-tab index="3" heading="Search" disable="true">
+        <div class="row">
+          <div class="row">
+            <div class="col-sm-offset-1 co-xs-12">
+              <h4>Search Fields</h4>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-2 col-sm-offset-1">
+              <div class="form-group">
+                <label for="key">Key</label>
+                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
+              </div>
+            </div>
+            <div class="col-xs-7">
+              <div class="form-group">
+                <label for="name">Label</label>
+                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.searchFields[0].label">
+              </div>
+            </div>
+            <div class="col-xs-2">
+              <div class="form-group add-field-group">
+                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem()"><span class="glyphicon glyphicon-plus"></span></button>
+              </div>
+            </div>
+          </div>
+          <div class="row" ng-repeat="searchField in discoveryViewToUpdate.searchFields track by $index" ng-hide="$first">
+            <div class="col-xs-2 col-sm-offset-1">
+              <div class="form-group">
+                <label for="key">Key</label>
+                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.searchFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
+              </div>
+            </div>
+            <div class="col-xs-7">
+              <div class="form-group">
+                <label for="label">Label</label>
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.searchFields[$index].label">
+              </div>
+            </div>
+            <div class="col-xs-2">
+              <div class="form-group add-field-group">
+                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToUpdate.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </uib-tab>
     </uib-tabset>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelUpdateDiscoveryView()">Cancel</button>
-
-
-    <button ng-show="activeJustified == 0" ng-disabled="updateDiscoveryViewGeneralIsInvalid()" type="button" class="btn btn-success" ng-click="activeJustified = 1; getFields(discoveryViewToUpdate);">Next</button>
+    <button ng-show="activeJustified == 0" ng-disabled="isDiscoveryViewGeneralInvalid('update')" type="button" class="btn btn-success" ng-click="activeJustified = 1; getFields(discoveryViewToUpdate)">Next</button>
     <button ng-show="activeJustified == 1" type="button" class="btn btn-success" ng-click="activeJustified = 0">Back</button>
-    <button ng-show="activeJustified == 1" ng-disabled="updateDiscoveryViewResultsIsInvalid()" type="button" class="btn btn-success" ng-click="activeJustified = 2">Next</button>
+    <button ng-show="activeJustified == 1" ng-disabled="isDiscoveryViewResultsInvalid('update')" type="button" class="btn btn-success" ng-click="activeJustified = 2">Next</button>
     <button ng-show="activeJustified == 2" type="button" class="btn btn-success" ng-click="activeJustified = 1">Back</button>
-    <button ng-show="activeJustified == 2" ng-disabled="discoveryViewForms.update.$invalid" type="submit" class="btn btn-success">Update</button>
+    <button ng-show="activeJustified == 2" ng-disabled="isDiscoveryViewFiltersInvalid('update')" type="button" class="btn btn-success" ng-click="activeJustified = 3">Next</button>
+    <button ng-show="activeJustified == 3" type="button" class="btn btn-success" ng-click="activeJustified = 2">Back</button>
+    <button ng-show="activeJustified == 3" ng-disabled="isDiscoveryViewSearchInvalid('update') || discoveryViewForms.update.$invalid" type="submit" class="btn btn-success">Update</button>
   </div>
 </form>

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -301,7 +301,7 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="discoveryViewToUpdate.facetFields.push({})"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryViewToUpdate)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
@@ -357,7 +357,7 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem()"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryViewToUpdate)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>

--- a/src/main/webapp/tests/core/mocks/mockAbstractCoreModel.js
+++ b/src/main/webapp/tests/core/mocks/mockAbstractCoreModel.js
@@ -1,0 +1,95 @@
+var mockModel = function (modelName, $q, mockDataObj) {
+    var model = {};
+    var combinationOperation = "";
+
+    model.isDirty = false;
+    model.isValid = false;
+
+    model.mock = function(toMock) {
+        if (typeof toMock === "object") {
+            var keys = Object.keys(toMock);
+            for (var i in keys) {
+                model[keys[i]] = toMock[keys[i]];
+            }
+        } else if (toMock === undefined || toMock === null) {
+            model = null;
+        }
+    };
+
+    model.mock(mockDataObj);
+
+    model.acceptPendingUpdate = function () {
+    };
+
+    model.acceptPendingDelete = function () {
+    };
+
+    model.before = function () {
+    };
+
+    model.clearListens = function() {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
+    model.clearValidationResults = function () {
+    };
+
+    model.delete = function() {
+        return payloadPromise($q.defer(), true);
+    };
+
+    model.dirty = function(boolean) {
+        if (boolean !== undefined) {
+            model.isDirty = boolean;
+        }
+
+        return model.isDirty;
+    };
+
+    model.enableMergeCombinationOperation = function () {
+        combinationOperation = "merge";
+    };
+
+    model.enableExtendCombinationOperation = function () {
+        combinationOperation = "extend";
+    };
+
+    model.fetch = function() {
+        return payloadPromise($q.defer(), mockDataObj);
+    };
+
+    model.getCombinationOperation = function () {
+        return combinationOperation;
+    };
+
+    model.getEntityName = function () {
+        return modelName;
+    };
+
+    model.getValidations = function () {
+        return null;
+    };
+
+    model.init = function (data, apiMapping) {
+    };
+
+    model.listen = function() {
+    };
+
+    model.refresh = function() {
+    };
+
+    model.reload = function() {
+    };
+
+    model.save = function() {
+        return payloadPromise($q.defer(), true);
+    };
+
+    model._syncShadow = function() {
+    };
+
+
+    return model;
+};

--- a/src/main/webapp/tests/core/mocks/mockAbstractCoreRepo.js
+++ b/src/main/webapp/tests/core/mocks/mockAbstractCoreRepo.js
@@ -1,0 +1,274 @@
+var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
+    var repo = {};
+
+    var validations = {};
+
+    var validationResults = {};
+
+    var originalList;
+
+    // set to TRUE to enable mocked models to be returned as the original object instead of a copy.
+    repo.mockSpyAssist = false;
+
+    repo.mockedList = [];
+
+    repo.mock = function(toMock) {
+        repo.mockedList = [];
+        originalList = [];
+
+        if (typeof mockModelCtor === "function" && typeof toMock === "object") {
+            for (var i in toMock) {
+                var model = repo.mockModel(toMock[i]);
+                repo.mockedList.push(model);
+                originalList.push(model);
+            }
+        }
+    };
+
+    repo.mockCopy = function(toCopy) {
+        if (repo.mockSpyAssist) {
+            return toCopy;
+        }
+
+        return angular.copy(toCopy);
+    };
+
+    repo.mockModel = function(toMock) {
+        if (typeof mockModelCtor === "function") {
+            var mocked = new mockModelCtor($q);
+            mocked.mock(toMock);
+            return mocked;
+        }
+
+        return toMock;
+    };
+
+    repo.mock(mockDataArray);
+
+    repo.acceptChangesPending = function () {
+    };
+
+    repo.add = function (modelJson) {
+        if (!repo.contains(modelJson)) {
+            repo.mockedList.push(modelJson);
+        }
+    };
+
+    repo.addAll = function (modelJsons) {
+        for (var i in modelJsons) {
+            repo.add(modelJsons[i]);
+        }
+    };
+
+    repo.changesPending = function () {
+        return false;
+    };
+
+    repo.clearValidationResults = function () {
+        validationResults = {};
+    };
+
+    repo.create = function (model) {
+        if (repo.mockedList === undefined) {
+            repo.mockedList = [];
+        }
+
+        model.id = repo.mockedList.length + 1;
+        repo.mockedList.push(repo.mockCopy(model));
+        return payloadPromise($q.defer(), model);
+    };
+
+    repo.contains = function (model) {
+        var found = false;
+        for (var i in repo.mockedList) {
+            if (repo.mockedList[i].id === model.id) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    };
+
+    repo.count = function () {
+        return repo.mockedList.length;
+    };
+
+    repo.delete = function (model) {
+        for (var i in repo.mockedList) {
+            if (repo.mockedList[i].id === model.id) {
+                repo.mockedList.splice(i, 1);
+                break;
+            }
+        }
+
+        return payloadPromise($q.defer());
+    };
+
+    repo.deleteById = function (id) {
+        for (var i in repo.mockedList) {
+            if (repo.mockedList[i].id === id) {
+                repo.mockedList.splice(i, 1);
+                break;
+            }
+        }
+
+        return payloadPromise($q.defer());
+    };
+
+    repo.empty = function () {
+        repo.list.length = 0;
+    };
+
+    repo.fetch = function () {
+        return payloadPromise($q.defer(), mockDataArray);
+    };
+
+    repo.findById = function (id) {
+        var found;
+        for (var i in repo.mockedList) {
+            if (repo.mockedList[i].id == id) {
+                found = repo.mockCopy(repo.mockedList[i]);
+            }
+        }
+
+        return found;
+    };
+
+    repo.getAll = function () {
+        return repo.mockCopy(repo.mockedList);
+    };
+
+    repo.getAllFiltered = function(predicate) {
+        var filteredData = [];
+
+        angular.forEach(repo.list, function(datum) {
+            if (predicate(datum)) {
+                filteredData.push(datum);
+            }
+        });
+
+        return filteredData;
+    };
+
+    repo.getContents = function () {
+        return repo.mockCopy(repo.mockedList);
+    };
+
+    repo.getEntityName = function () {
+        return repoName;
+    };
+
+    repo.getValidations = function () {
+        return repo.mockCopy(validations);
+    };
+
+    repo.getValidationResults = function () {
+        return repo.mockCopy(validationResults);
+    };
+
+    repo.listen = function (cbOrActionOrActionArray, cb) {
+        if (typeof cbOrActionOrActionArray === "function") {
+            var apiRes = {
+                meta: {
+                    status: "SUCCESS",
+                    message: ""
+                },
+                status: 200
+            };
+            cbOrActionOrActionArray(apiRes);
+        } else if (Array.isArray(cbOrActionOrActionArray)) {
+            for (var cbAction in cbOrActionOrActionArray) {
+                if (typeof cbAction === "function") {
+                    cbAction();
+                }
+            }
+        } else if (typeof cb === "function") {
+            cb();
+        }
+
+        return payloadPromise($q.defer());
+    };
+
+    repo.ready = function () {
+        return payloadPromise($q.defer(), mockDataArray);
+    };
+
+    repo.remove = function (modelToRemove) {
+        if (typeof modelToRemove === "object") {
+            for (var i in repo.mockedList) {
+                if (repo.mockedList[i].id === modelToRemove.id) {
+                    repo.mockedList.splice(i, 1);
+                    break;
+                }
+            }
+        }
+    };
+
+    repo.reorder = function (src, dest) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
+    repo.reset = function () {
+        repo.mockedList = repo.originalList;
+        return payloadPromise($q.defer());
+    };
+
+    repo.save = function (modelToSave) {
+        if (typeof modelToSave === "object") {
+            var isNew = true;
+            var savedModel = repo.mockModel(modelToSave);
+
+            for (var i in repo.mockedList) {
+                if (repo.mockedList[i].id === modelToSave.id) {
+                    angular.extend(repo.mockedList[i], savedModel);
+                    isNew = false;
+                    break;
+                }
+            }
+
+            if (isNew) {
+                repo.mockedList[repo.mockedList.length] = savedModel;
+            }
+
+            return payloadPromise($q.defer(), savedModel);
+        }
+
+        return rejectPromise($q.defer());
+    };
+
+    repo.saveAll = function () {
+        angular.forEach(repo.mockedList, function (model) {
+            repo.save(model);
+        });
+    };
+
+    repo.setToDelete = function (id) {
+    };
+
+    repo.setToUpdate = function (id) {
+    };
+
+    repo.sort = function (guarantor, facet) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
+    repo.unshift = function (modelJson) {
+    };
+
+    repo.update = function (model) {
+        var updated;
+        for (var i in repo.mockedList) {
+            if (repo.mockedList[i].id === model.id) {
+                updated = repo.mockCopy(repo.mockedList[i]);
+                angular.extend(updated, model);
+                break;
+            }
+        }
+
+        return payloadPromise($q.defer(), updated);
+    };
+
+    return repo;
+};

--- a/src/main/webapp/tests/core/mocks/mockAbstractCoreService.js
+++ b/src/main/webapp/tests/core/mocks/mockAbstractCoreService.js
@@ -1,0 +1,15 @@
+var mockService = function ($q, mockModelCtor) {
+    var service = {};
+
+    service.mockModel = function(toMock) {
+        if (typeof mockModelCtor === "function") {
+            var mocked = new mockModelCtor($q);
+            mocked.mock(toMock);
+            return mocked;
+        }
+
+        return toMock;
+    };
+
+    return service;
+};

--- a/src/main/webapp/tests/core/utility/coreUtility.js
+++ b/src/main/webapp/tests/core/utility/coreUtility.js
@@ -1,0 +1,125 @@
+// provide common helper methods to be used by mocks.
+
+var messagePromise = function (defer, message, messageStatus, httpStatus) {
+     defer.resolve({
+        body: angular.toJson({
+            meta: {
+                status: messageStatus ? messageStatus : "SUCCESS",
+                message: message
+            },
+            status: httpStatus ? httpStatus : 200
+        })
+    });
+    return defer.promise;
+};
+
+var valuePromise = function (defer, model, type, timeout) {
+    if (type === "reject") {
+        defer.reject(model);
+    } else if (type === "notify") {
+        timeout(function () {
+            defer.notify(model);
+        }, 0);
+    } else {
+        defer.resolve(model);
+    }
+
+    return defer.promise;
+};
+
+var payloadPromise = function (defer, payload, messageStatus, httpStatus) {
+    defer.resolve({
+        body: angular.toJson({
+            meta: {
+                status: messageStatus ? messageStatus : "SUCCESS",
+            },
+            payload: payload,
+            status: httpStatus ? httpStatus : 200
+        })
+    });
+    return defer.promise;
+};
+
+var dataPromise = function (defer, payload, messageStatus, httpStatus) {
+    defer.resolve({
+        data: {
+            meta: {
+                status: messageStatus ? messageStatus : "SUCCESS",
+            },
+            payload: payload,
+            status: httpStatus ? httpStatus : 200
+        }
+    });
+    return defer.promise;
+};
+
+var rejectPromise = function (defer, payload, messageStatus, httpStatus) {
+    defer.reject({
+        body: angular.toJson({
+            meta: {
+                status: messageStatus ? messageStatus : "INVALID",
+            },
+            payload: payload,
+            status: httpStatus ? httpStatus : 200
+        })
+    });
+    return defer.promise;
+};
+
+var failurePromise = function (defer, payload, messageStatus, httpStatus) {
+    defer.reject({
+        data: {
+            meta: {
+                status: messageStatus ? messageStatus : "INVALID",
+            },
+            payload: payload,
+            status: httpStatus ? httpStatus : 500
+        }
+    });
+    return defer.promise;
+};
+
+var notifyPromise = function (timeout, defer, payload, messageStatus, httpStatus) {
+    timeout(function () {
+        defer.notify({
+            body: angular.toJson({
+                meta: {
+                    status: messageStatus ? messageStatus : "SUCCESS",
+                },
+                payload: payload,
+                status: httpStatus ? httpStatus : 200
+            })
+        });
+    }, 0);
+    return defer.promise;
+};
+
+var mockParameterModel = function($q, mockModel) {
+    return function(toMock) {
+        var model = new mockModel($q);
+        model.mock(toMock);
+        return model;
+    };
+};
+
+var mockParameterConstructor = function(mockConstructor) {
+    return function() { return mockConstructor; };
+};
+
+var mockWindow = function() {
+    return {
+        location: {
+            href: "",
+            replace: function() {}
+        }
+    };
+};
+
+var mockForms = function() {
+    return {
+        $pristine: true,
+        $untouched: true,
+        $setPristine: function (value) { this.$pristine = value; },
+        $setUntouched: function (value) { this.$untouched = value; }
+    };
+};

--- a/src/main/webapp/tests/core/utility/testUtility.js
+++ b/src/main/webapp/tests/core/utility/testUtility.js
@@ -1,0 +1,23 @@
+// provide tests or parts of tests that are commonly performed.
+
+var testUtility = {};
+
+testUtility.repoSorting = function(scope, repo, method) {
+    spyOn(repo, "sort");
+
+    scope.sortAction = "confirm";
+    method("column");
+
+    expect(scope.sortAction).toEqual("sort");
+    expect(repo.sort).not.toHaveBeenCalled();
+
+    scope.sortAction = "sort";
+    method("column");
+
+    expect(scope.sortAction).toEqual("confirm");
+    expect(repo.sort).toHaveBeenCalled();
+
+    scope.sortAction = "unknown";
+    method("column");
+    expect(scope.sortAction).toEqual("unknown");
+};

--- a/src/main/webapp/tests/karma.conf.js
+++ b/src/main/webapp/tests/karma.conf.js
@@ -60,6 +60,8 @@ module.exports = function(config){
 
       'app/model/**/*.js',
 
+      'tests/core/**/*.js',
+
       'tests/mocks/**/*.js',
 
       'tests/unit/**/*.js'

--- a/src/main/webapp/tests/mocks/model/mockAbstractAppModel.js
+++ b/src/main/webapp/tests/mocks/model/mockAbstractAppModel.js
@@ -1,0 +1,31 @@
+var dataAbstractAppModel1 = {
+    id: 1
+};
+
+var dataAbstractAppModel2 = {
+    id: 2
+};
+
+var mockAbstractAppModel3 = {
+    id: 3
+};
+
+var dataAbstractAppModel4 = {
+    id: 4
+};
+
+var dataAbstractAppModel5 = {
+    id: 5
+};
+
+var mockAbstractAppModel6 = {
+    id: 6
+};
+
+var mockAbstractAppModel = function($q) {
+    var model = mockModel("AbstractAppModel", $q, dataAbstractAppModel1);
+
+    return model;
+};
+
+angular.module("mock.abstractAppModel", []).service("AbstractAppModel", mockAbstractAppModel);

--- a/src/main/webapp/tests/mocks/model/mockDiscoveryContext.js
+++ b/src/main/webapp/tests/mocks/model/mockDiscoveryContext.js
@@ -1,0 +1,35 @@
+var dataDiscoveryContext1 = {
+    id: 1
+};
+
+var dataDiscoveryContext2 = {
+    id: 2
+};
+
+var mockDiscoveryContext3 = {
+    id: 3
+};
+
+var dataDiscoveryContext4 = {
+    id: 4
+};
+
+var dataDiscoveryContext5 = {
+    id: 5
+};
+
+var mockDiscoveryContext6 = {
+    id: 6
+};
+
+var mockDiscoveryContext = function($q) {
+    var model = mockModel("DiscoveryContext", $q, dataDiscoveryContext1);
+
+    model.ready = function() {
+      return $q.defer().promise;
+    }
+
+    return model;
+};
+
+angular.module("mock.discoveryContext", []).service("DiscoveryContext", mockDiscoveryContext);

--- a/src/main/webapp/tests/mocks/model/mockDiscoveryView.js
+++ b/src/main/webapp/tests/mocks/model/mockDiscoveryView.js
@@ -1,0 +1,115 @@
+var dataDiscoveryView1 = {
+    id: 1,
+    facetFields: [],
+    filter: "filter",
+    infoLinkText: "infoLinkText",
+    infoLinkUrl: "http://example.com/",
+    infoText: "infoText",
+    name: "Discovery View 1",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resultMetadataFields: [],
+    searchFields: [],
+    slug: "slug",
+    source: "source",
+    titleKey: "titleKey",
+    uniqueIdentifierKey: "uniqueIdentifierKey"
+};
+
+var dataDiscoveryView2 = {
+    id: 2,
+    facetFields: [],
+    filter: "filter",
+    infoLinkText: "infoLinkText",
+    infoLinkUrl: "http://example.com/",
+    infoText: "infoText",
+    name: "Discovery View 2",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resultMetadataFields: [],
+    searchFields: [],
+    slug: "slug",
+    source: "source",
+    titleKey: "titleKey",
+    uniqueIdentifierKey: "uniqueIdentifierKey"
+};
+
+var mockDiscoveryView3 = {
+    id: 3,
+    facetFields: [],
+    filter: "filter",
+    infoLinkText: "infoLinkText",
+    infoLinkUrl: "http://example.com/",
+    infoText: "infoText",
+    name: "Discovery View 3",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resultMetadataFields: [],
+    searchFields: [],
+    slug: "slug",
+    source: "source",
+    titleKey: "titleKey",
+    uniqueIdentifierKey: "uniqueIdentifierKey"
+};
+
+var dataDiscoveryView4 = {
+    id: 4,
+    facetFields: [],
+    filter: "filter",
+    infoLinkText: "infoLinkText",
+    infoLinkUrl: "http://example.com/",
+    infoText: "infoText",
+    name: "Discovery View 4",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resultMetadataFields: [],
+    searchFields: [],
+    slug: "slug",
+    source: "source",
+    titleKey: "titleKey",
+    uniqueIdentifierKey: "uniqueIdentifierKey"
+};
+
+var dataDiscoveryView5 = {
+    id: 5,
+    facetFields: [],
+    filter: "filter",
+    infoLinkText: "infoLinkText",
+    infoLinkUrl: "http://example.com/",
+    infoText: "infoText",
+    name: "Discovery View 5",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resultMetadataFields: [],
+    searchFields: [],
+    slug: "slug",
+    source: "source",
+    titleKey: "titleKey",
+    uniqueIdentifierKey: "uniqueIdentifierKey"
+};
+
+var mockDiscoveryView6 = {
+    id: 6,
+    facetFields: [],
+    filter: "filter",
+    infoLinkText: "infoLinkText",
+    infoLinkUrl: "http://example.com/",
+    infoText: "infoText",
+    name: "Discovery View 6",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resultMetadataFields: [],
+    searchFields: [],
+    slug: "slug",
+    source: "source",
+    titleKey: "titleKey",
+    uniqueIdentifierKey: "uniqueIdentifierKey"
+};
+
+var mockDiscoveryView = function($q) {
+    var model = mockModel("DiscoveryView", $q, dataDiscoveryView1);
+
+    return model;
+};
+
+angular.module("mock.discoveryView", []).service("DiscoveryView", mockDiscoveryView);

--- a/src/main/webapp/tests/mocks/model/mockField.js
+++ b/src/main/webapp/tests/mocks/model/mockField.js
@@ -1,0 +1,43 @@
+var dataField1 = {
+    id: 1,
+    name: "Field 1",
+    schemaMapping: "schemaMapping"
+};
+
+var dataField2 = {
+    id: 2,
+    name: "Field 2",
+    schemaMapping: "schemaMapping"
+};
+
+var mockField3 = {
+    id: 3,
+    name: "Field 3",
+    schemaMapping: "schemaMapping"
+};
+
+var dataField4 = {
+    id: 4,
+    name: "Field 4",
+    schemaMapping: "schemaMapping"
+};
+
+var dataField5 = {
+    id: 5,
+    name: "Field 5",
+    schemaMapping: "schemaMapping"
+};
+
+var mockField6 = {
+    id: 6,
+    name: "Field 6",
+    schemaMapping: "schemaMapping"
+};
+
+var mockField = function($q) {
+    var model = mockModel("Field", $q, dataField1);
+
+    return model;
+};
+
+angular.module("mock.field", []).service("Field", mockField);

--- a/src/main/webapp/tests/mocks/model/mockNgTableParams.js
+++ b/src/main/webapp/tests/mocks/model/mockNgTableParams.js
@@ -1,53 +1,51 @@
-var mockNgTableParams1 = {
+var dataNgTableParams1 = {
+    id: 1,
+    data: []
 };
 
-var mockNgTableParams2 = {
+var dataNgTableParams2 = {
+    id: 2,
+    data: []
 };
 
-var mockNgTableParams3 = {
+var dataNgTableParams3 = {
+    id: 3,
+    data: []
 };
 
-angular.module('mock.ngTableParams', []).service('NgTableParams', function ($q) {
-  return function () {
-    var defer;
-    var payloadResponse = function (payload) {
-      return defer.resolve({
-        body: angular.toJson({
-          meta: {
-            status: 'SUCCESS'
-          },
-          payload: payload
-        })
-      });
+var dataNgTableParams4 = {
+    id: 4,
+    data: []
+};
+
+var dataNgTableParams5 = {
+    id: 5,
+    data: []
+};
+
+var dataNgTableParams6 = {
+    id: 6,
+    data: []
+};
+
+var mockNgTableParams = function($q) {
+    var model = mockModel("NgTableParams", $q, dataNgTableParams1);
+
+    model.count = function() {
+        var total = 0;
+        return total;
     };
 
-    this.isDirty = false;
-
-    this.mock = function(toMock) {
+    model.sorting = function(sort) {
+        return {};
     };
 
-    this.save = function() {
-      defer = $q.defer();
-      payloadResponse();
-      return defer.promise;
+    model.page = function(sort) {
+        return {};
     };
 
-    this.delete = function() {
-      defer = $q.defer();
-      payloadResponse();
-      return defer.promise;
-    };
+    return model;
+};
 
-    this.dirty = function(boolean) {
-        this.isDirty = boolean;
-    };
+angular.module("mock.ngTableParams", []).service("NgTableParams", mockNgTableParams);
 
-    this.reload = function() {
-    };
-
-    this.clearValidationResults = function () {
-    };
-
-    return this;
-  };
-});

--- a/src/main/webapp/tests/mocks/model/mockResult.js
+++ b/src/main/webapp/tests/mocks/model/mockResult.js
@@ -1,0 +1,73 @@
+var dataResult1 = {
+    id: 1,
+    fields: [],
+    inList: true,
+    inGrid: false,
+    title: "Result 1",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var dataResult2 = {
+    id: 2,
+    fields: [],
+    inList: true,
+    inGrid: false,
+    title: "Result 2",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var mockResult3 = {
+    id: 3,
+    fields: [],
+    inList: false,
+    inGrid: false,
+    title: "Result 3",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var dataResult4 = {
+    id: 4,
+    fields: [],
+    inList: false,
+    inGrid: true,
+    title: "Result 4",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var dataResult5 = {
+    id: 5,
+    fields: [],
+    inList: true,
+    inGrid: true,
+    title: "Result 5",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var mockResult6 = {
+    id: 6,
+    fields: [],
+    inList: false,
+    inGrid: false,
+    title: "Result 6",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var mockResult = function($q) {
+    var model = mockModel("Result", $q, dataResult1);
+
+    return model;
+};
+
+angular.module("mock.result", []).service("Result", mockResult);

--- a/src/main/webapp/tests/mocks/model/mockSearch.js
+++ b/src/main/webapp/tests/mocks/model/mockSearch.js
@@ -1,0 +1,31 @@
+var dataSearch1 = {
+    id: 1
+};
+
+var dataSearch2 = {
+    id: 2
+};
+
+var mockSearch3 = {
+    id: 3
+};
+
+var dataSearch4 = {
+    id: 4
+};
+
+var dataSearch5 = {
+    id: 5
+};
+
+var mockSearch6 = {
+    id: 6
+};
+
+var mockSearch = function($q) {
+    var model = mockModel("Search", $q, dataSearch1);
+
+    return model;
+};
+
+angular.module("mock.search", []).service("Search", mockSearch);

--- a/src/main/webapp/tests/mocks/model/mockSearchField.js
+++ b/src/main/webapp/tests/mocks/model/mockSearchField.js
@@ -1,0 +1,43 @@
+var dataSearchField1 = {
+    id: 1,
+    key: "search_field_1",
+    label: "Search Field 1"
+};
+
+var dataSearchField2 = {
+    id: 2,
+    key: "search_field_2",
+    label: "Search Field 2"
+};
+
+var mockSearchField3 = {
+    id: 3,
+    key: "search_field_3",
+    label: "Search Field 3"
+};
+
+var dataSearchField4 = {
+    id: 4,
+    key: "search_field_4",
+    label: "Search Field 4"
+};
+
+var dataSearchField5 = {
+    id: 5,
+    key: "search_field_5",
+    label: "Search Field 5"
+};
+
+var mockSearchField6 = {
+    id: 6,
+    key: "search_field_6",
+    label: "Search Field 6"
+};
+
+var mockSearchField = function($q) {
+    var model = mockModel("SearchField", $q, dataSearchField1);
+
+    return model;
+};
+
+angular.module("mock.searchField", []).service("SearchField", mockSearchField);

--- a/src/main/webapp/tests/mocks/model/mockSingleResultContext.js
+++ b/src/main/webapp/tests/mocks/model/mockSingleResultContext.js
@@ -1,0 +1,73 @@
+var dataSingleResultContext1 = {
+    id: 1,
+    fields: [],
+    inList: true,
+    inGrid: false,
+    title: "Result 1",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var dataSingleResultContext2 = {
+    id: 2,
+    fields: [],
+    inList: true,
+    inGrid: false,
+    title: "Result 2",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var mockSingleResultContext3 = {
+    id: 3,
+    fields: [],
+    inList: false,
+    inGrid: false,
+    title: "Result 3",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var dataSingleResultContext4 = {
+    id: 4,
+    fields: [],
+    inList: false,
+    inGrid: true,
+    title: "Result 4",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var dataSingleResultContext5 = {
+    id: 5,
+    fields: [],
+    inList: true,
+    inGrid: true,
+    title: "Result 5",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var mockSingleResultContext6 = {
+    id: 6,
+    fields: [],
+    inList: false,
+    inGrid: false,
+    title: "Result 6",
+    resourceLocationUriKey: "resourceLocationUriKey",
+    resourceThumbnailUriKey: "resourceThumbnailUriKey",
+    uniqueIdentifier: "uniqueIdentifier"
+};
+
+var mockSingleResultContext = function($q) {
+    var model = mockModel("SingleResultContext", $q, dataSingleResultContext1);
+
+    return model;
+};
+
+angular.module("mock.singleResultContext", []).service("SingleResultContext", mockSingleResultContext);

--- a/src/main/webapp/tests/mocks/repo/mockAbstractAppRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockAbstractAppRepo.js
@@ -1,0 +1,5 @@
+angular.module("mock.abstractAppRepo", []).service("AbstractAppRepo", function($q) {
+    var repo = mockRepo("AbstractAppRepo", $q);
+
+    return repo;
+});

--- a/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
@@ -1,0 +1,40 @@
+angular.module("mock.discoveryViewRepo", []).service("DiscoveryViewRepo", function($q, ) {
+    var repo = mockRepo("DiscoveryViewRepo", $q);
+
+    repo.scaffold = {
+        name: "",
+        source: "",
+        facetFields: [],
+        filter: "*:*",
+        resourceLocationUriKey: "",
+        resourceThumbnailUriKey: "",
+        resultMetadataFields: [],
+        searchFields: [ {
+            key: "all_fields",
+            label: "Everything"
+        }],
+        slug: "",
+        titleKey: "",
+        infoLinkText: "",
+        infoLinkUrl: "",
+        infoText: "",
+        uniqueIdentifierKey: "",
+        dirty: function(boolean) {
+          this.isDirty = boolean;
+        }
+    };
+
+    repo.scaffoldSearchField = {
+        key: "",
+        label: "",
+        dirty: function(boolean) {
+          this.isDirty = boolean;
+        }
+    };
+
+    repo.getScaffold = function() {
+      return repo.scaffold;
+    };
+
+    return repo;
+});

--- a/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
@@ -18,18 +18,12 @@ angular.module("mock.discoveryViewRepo", []).service("DiscoveryViewRepo", functi
         infoLinkText: "",
         infoLinkUrl: "",
         infoText: "",
-        uniqueIdentifierKey: "",
-        dirty: function(boolean) {
-          this.isDirty = boolean;
-        }
+        uniqueIdentifierKey: ""
     };
 
     repo.scaffoldSearchField = {
         key: "",
-        label: "",
-        dirty: function(boolean) {
-          this.isDirty = boolean;
-        }
+        label: ""
     };
 
     repo.getScaffold = function() {

--- a/src/main/webapp/tests/mocks/repo/mockSourceRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockSourceRepo.js
@@ -103,6 +103,11 @@ angular.module('mock.sourceRepo', []).service('SourceRepo', function ($q) {
     return angular.copy(sourceRepo.list);
   };
 
+  sourceRepo.getAvailableFields = function() {
+    // @todo
+    return [];
+  };
+
   sourceRepo.getScaffold = function(defaults) {
     var updatedScaffold = scaffold;
     if (!defaults) defaults = {};

--- a/src/main/webapp/tests/unit/controllers/discoveryContextControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/discoveryContextControllerTest.js
@@ -1,0 +1,170 @@
+describe("controller: DiscoveryContextController", function () {
+
+    var controller, location, q, scope, appConfig, routeParams, DiscoveryContext, MockedDiscoveryContext, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $q, _WsApi_) {
+            location = $location;
+            q = $q;
+
+            routeParams = settings && settings.routeParams ? settings.routeParams : {};
+            appConfig = settings && settings.appConfig ? settings.appConfig : { defaultThumbnailURI: "thumbnail.png" };
+
+            MockedDiscoveryContext = new mockDiscoveryContext(q);
+            DiscoveryContext = function() {
+              return MockedDiscoveryContext;
+            };
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeController = function(settings) {
+        inject(function ($controller, $rootScope) {
+            scope = $rootScope.$new();
+
+            sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
+            sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
+
+            if (settings) {
+              if (settings.appConfig) {
+                appConfig = settings.appConfig;
+              }
+
+              if (settings.routeParams) {
+                routeParams = settings.routeParams;
+              }
+            }
+
+            controller = $controller("DiscoveryContextController", {
+                $location: location,
+                $routeParams: routeParams,
+                $scope: scope,
+                appConfig: appConfig,
+                DiscoveryContext: DiscoveryContext,
+                WsApi: WsApi
+            });
+
+            // ensure that the isReady() is called.
+            if (!scope.$$phase) {
+                scope.$digest();
+            }
+        });
+    };
+
+    beforeEach(function() {
+        module("core");
+        module("sage");
+        module("mock.wsApi");
+        module("mock.discoveryContext");
+
+        installPromiseMatchers();
+        initializeVariables();
+        initializeController();
+    });
+
+    describe("Is the controller defined", function () {
+        it("should be defined for admin", function () {
+            expect(controller).toBeDefined();
+        });
+        it("should be defined for manager", function () {
+            initializeController({role: "ROLE_MANAGER"});
+            expect(controller).toBeDefined();
+        });
+        it("should be defined for user", function () {
+            initializeController({role: "ROLE_USER"});
+            expect(controller).toBeDefined();
+        });
+        it("should be defined for anonymous", function () {
+            initializeController({role: "ROLE_ANONYMOUS"});
+            expect(controller).toBeDefined();
+        });
+    });
+/*
+    describe("Are the scope methods defined", function () {
+        it("clearFilters should be defined", function () {
+            expect(scope.clearFilters).toBeDefined();
+            expect(typeof scope.clearFilters).toEqual("function");
+        });
+        it("pageBack should be defined", function () {
+            expect(scope.pageBack).toBeDefined();
+            expect(typeof scope.pageBack).toEqual("function");
+        });
+        it("pageForward should be defined", function () {
+            expect(scope.pageForward).toBeDefined();
+            expect(typeof scope.pageForward).toEqual("function");
+        });
+        it("removeFilter should be defined", function () {
+            expect(scope.removeFilter).toBeDefined();
+            expect(typeof scope.removeFilter).toEqual("function");
+        });
+        it("resetSearch should be defined", function () {
+            expect(scope.resetSearch).toBeDefined();
+            expect(typeof scope.resetSearch).toEqual("function");
+        });
+        it("searchProcessKeyPress should be defined", function () {
+            expect(scope.searchProcessKeyPress).toBeDefined();
+            expect(typeof scope.searchProcessKeyPress).toEqual("function");
+        });
+        it("updateLimit should be defined", function () {
+            expect(scope.updateLimit).toBeDefined();
+            expect(typeof scope.updateLimit).toEqual("function");
+        });
+        it("updateSort should be defined", function () {
+            expect(scope.updateSort).toBeDefined();
+            expect(typeof scope.updateSort).toEqual("function");
+        });
+    });
+
+    describe("Do the scope methods work as expected", function () {
+        it("clearFilters should work", function () {
+            var result;
+
+            result = scope.clearFilters();
+            // @todo
+        });
+        it("pageBack should work", function () {
+            var result;
+
+            result = scope.pageBack();
+            // @todo
+        });
+        it("pageForward should work", function () {
+            var result;
+
+            result = scope.pageForward();
+            // @todo
+        });
+        it("removeFilter should work", function () {
+            var result;
+
+            result = scope.removeFilter();
+            // @todo
+        });
+        it("resetSearch should work", function () {
+            var result;
+
+            result = scope.resetSearch();
+            // @todo
+        });
+        it("searchProcessKeyPress should work", function () {
+            var result;
+
+            result = scope.searchProcessKeyPress();
+            // @todo
+        });
+        it("updateLimit should work", function () {
+            var result;
+
+            result = scope.updateLimit();
+            // @todo
+        });
+        it("updateSort should work", function () {
+            var result;
+
+            result = scope.updateSort();
+            // @todo
+        });
+    });
+*/
+});

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -17,17 +17,6 @@ describe("controller: DiscoveryViewManagementController", function () {
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
 
-            if (settings) {
-              if (settings.discoveryViewForms) {
-                scope.discoveryViewForms = settings.discoveryViewForms;
-              } else {
-                scope.discoveryViewForms = {
-                  create: new mockDiscoveryView(q),
-                  update: new mockDiscoveryView(q)
-                };
-              }
-            }
-
             controller = $controller("DiscoveryViewManagementController", {
                 $scope: scope,
                 DiscoveryViewRepo: _DiscoveryViewRepo_,
@@ -211,7 +200,7 @@ describe("controller: DiscoveryViewManagementController", function () {
 
             result = scope.getFields();
             // @todo
-        });/*
+        });
         it("isDiscoveryViewFacetsInvalid should work", function () {
             var result;
 
@@ -220,12 +209,16 @@ describe("controller: DiscoveryViewManagementController", function () {
         });
         it("isDiscoveryViewGeneralInvalid should work", function () {
             var result;
+            scope.discoveryViewForms = {};
+            scope.discoveryViewForms.create = new mockDiscoveryView(q);
 
             result = scope.isDiscoveryViewGeneralInvalid("create");
             // @todo
         });
         it("isDiscoveryViewResultsInvalid should work", function () {
             var result;
+            scope.discoveryViewForms = {};
+            scope.discoveryViewForms.create = new mockDiscoveryView(q);
 
             result = scope.isDiscoveryViewResultsInvalid("create");
             // @todo
@@ -235,7 +228,7 @@ describe("controller: DiscoveryViewManagementController", function () {
 
             result = scope.isDiscoveryViewSearchInvalid("create");
             // @todo
-        });*/
+        });
         it("resetDiscoveryViewForms should work", function () {
             var result;
 
@@ -255,14 +248,13 @@ describe("controller: DiscoveryViewManagementController", function () {
             result = scope.startUpdateDiscoveryView(dv);
             // @todo
         });
-        /*
         it("updateDiscoveryView should work", function () {
             var result;
+            scope.discoveryViewToUpdate = new mockDiscoveryView(q);
 
             result = scope.updateDiscoveryView();
             // @todo
         });
-        */
     });
 
 });

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -75,6 +75,10 @@ describe("controller: DiscoveryViewManagementController", function () {
     });
 
     describe("Are the scope methods defined", function () {
+        it("appendFacetFieldItem should be defined", function () {
+            expect(scope.appendFacetFieldItem).toBeDefined();
+            expect(typeof scope.appendFacetFieldItem).toEqual("function");
+        });
         it("appendSearchFieldItem should be defined", function () {
             expect(scope.appendSearchFieldItem).toBeDefined();
             expect(typeof scope.appendSearchFieldItem).toEqual("function");
@@ -146,10 +150,18 @@ describe("controller: DiscoveryViewManagementController", function () {
     });
 
     describe("Do the scope methods work as expected", function () {
+        it("appendFacetFieldItem should work", function () {
+            var result;
+            var dv = new mockDiscoveryView(q);
+
+            result = scope.appendFacetFieldItem(dv);
+            // @todo
+        });
         it("appendSearchFieldItem should work", function () {
             var result;
+            var dv = new mockDiscoveryView(q);
 
-            result = scope.appendSearchFieldItem();
+            result = scope.appendSearchFieldItem(dv);
             // @todo
         });
         it("cancelCreateDiscoveryView should work", function () {

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -1,11 +1,12 @@
 describe("controller: DiscoveryViewManagementController", function () {
-    var controller, q, scope, NgTableParams, WsApi;
+    var controller, q, scope, NgTableParams, SearchField, WsApi;
 
     var initializeVariables = function(settings) {
         inject(function ($q, _WsApi_) {
             q = $q;
 
             NgTableParams = mockNgTableParams;
+            SearchField = mockSearchField;
             WsApi = _WsApi_;
         });
     };
@@ -21,6 +22,7 @@ describe("controller: DiscoveryViewManagementController", function () {
                 $scope: scope,
                 DiscoveryViewRepo: _DiscoveryViewRepo_,
                 NgTableParams: mockNgTableParams,
+                SearchField: SearchField,
                 SourceRepo: _SourceRepo_,
                 WsApi: WsApi
             });
@@ -37,6 +39,7 @@ describe("controller: DiscoveryViewManagementController", function () {
         module("sage");
         module("mock.discoveryView");
         module("mock.discoveryViewRepo");
+        module("mock.searchField");
         module("mock.sourceRepo");
         module("mock.wsApi");
 

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -1,0 +1,256 @@
+describe("controller: DiscoveryViewManagementController", function () {
+    var controller, q, scope, NgTableParams, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($q, _WsApi_) {
+            q = $q;
+
+            NgTableParams = mockNgTableParams;
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeController = function(settings) {
+        inject(function ($controller, $rootScope, _DiscoveryViewRepo_, _SourceRepo_) {
+            scope = $rootScope.$new();
+
+            sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
+            sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
+
+            if (settings) {
+              if (settings.discoveryViewForms) {
+                scope.discoveryViewForms = settings.discoveryViewForms;
+              } else {
+                scope.discoveryViewForms = {
+                  create: new mockDiscoveryView(q),
+                  update: new mockDiscoveryView(q)
+                };
+              }
+            }
+
+            controller = $controller("DiscoveryViewManagementController", {
+                $scope: scope,
+                DiscoveryViewRepo: _DiscoveryViewRepo_,
+                NgTableParams: mockNgTableParams,
+                SourceRepo: _SourceRepo_,
+                WsApi: WsApi
+            });
+
+            // ensure that the isReady() is called.
+            if (!scope.$$phase) {
+                scope.$digest();
+            }
+        });
+    };
+
+    beforeEach(function() {
+        module("core");
+        module("sage");
+        module("mock.discoveryView");
+        module("mock.discoveryViewRepo");
+        module("mock.sourceRepo");
+        module("mock.wsApi");
+
+        installPromiseMatchers();
+        initializeVariables();
+        initializeController();
+    });
+
+    describe("Is the controller defined", function () {
+        it("should be defined for admin", function () {
+            expect(controller).toBeDefined();
+        });
+        it("should be defined for manager", function () {
+            initializeController({role: "ROLE_MANAGER"});
+            expect(controller).toBeDefined();
+        });
+        it("should be defined for user", function () {
+            initializeController({role: "ROLE_USER"});
+            expect(controller).toBeDefined();
+        });
+        it("should be defined for anonymous", function () {
+            initializeController({role: "ROLE_ANONYMOUS"});
+            expect(controller).toBeDefined();
+        });
+    });
+
+    describe("Are the scope methods defined", function () {
+        it("appendSearchFieldItem should be defined", function () {
+            expect(scope.appendSearchFieldItem).toBeDefined();
+            expect(typeof scope.appendSearchFieldItem).toEqual("function");
+        });
+        it("cancelCreateDiscoveryView should be defined", function () {
+            expect(scope.cancelCreateDiscoveryView).toBeDefined();
+            expect(typeof scope.cancelCreateDiscoveryView).toEqual("function");
+        });
+        it("cancelDeleteDiscoveryView should be defined", function () {
+            expect(scope.cancelDeleteDiscoveryView).toBeDefined();
+            expect(typeof scope.cancelDeleteDiscoveryView).toEqual("function");
+        });
+        it("cancelUpdateDiscoveryView should be defined", function () {
+            expect(scope.cancelUpdateDiscoveryView).toBeDefined();
+            expect(typeof scope.cancelUpdateDiscoveryView).toEqual("function");
+        });
+        it("confirmDeleteDiscoveryView should be defined", function () {
+            expect(scope.confirmDeleteDiscoveryView).toBeDefined();
+            expect(typeof scope.confirmDeleteDiscoveryView).toEqual("function");
+        });
+        it("createDiscoveryView should be defined", function () {
+            expect(scope.createDiscoveryView).toBeDefined();
+            expect(typeof scope.createDiscoveryView).toEqual("function");
+        });
+        it("deleteDiscoveryView should be defined", function () {
+            expect(scope.deleteDiscoveryView).toBeDefined();
+            expect(typeof scope.deleteDiscoveryView).toEqual("function");
+        });
+        it("findFieldByKey should be defined", function () {
+            expect(scope.findFieldByKey).toBeDefined();
+            expect(typeof scope.findFieldByKey).toEqual("function");
+        });
+        it("getFields should be defined", function () {
+            expect(scope.getFields).toBeDefined();
+            expect(typeof scope.getFields).toEqual("function");
+        });
+        it("isDiscoveryViewFacetsInvalid should be defined", function () {
+            expect(scope.isDiscoveryViewFacetsInvalid).toBeDefined();
+            expect(typeof scope.isDiscoveryViewFacetsInvalid).toEqual("function");
+        });
+        it("isDiscoveryViewGeneralInvalid should be defined", function () {
+            expect(scope.isDiscoveryViewGeneralInvalid).toBeDefined();
+            expect(typeof scope.isDiscoveryViewGeneralInvalid).toEqual("function");
+        });
+        it("isDiscoveryViewResultsInvalid should be defined", function () {
+            expect(scope.isDiscoveryViewResultsInvalid).toBeDefined();
+            expect(typeof scope.isDiscoveryViewResultsInvalid).toEqual("function");
+        });
+        it("isDiscoveryViewSearchInvalid should be defined", function () {
+            expect(scope.isDiscoveryViewSearchInvalid).toBeDefined();
+            expect(typeof scope.isDiscoveryViewSearchInvalid).toEqual("function");
+        });
+        it("resetDiscoveryViewForms should be defined", function () {
+            expect(scope.resetDiscoveryViewForms).toBeDefined();
+            expect(typeof scope.resetDiscoveryViewForms).toEqual("function");
+        });
+        it("startCreateDiscoveryView should be defined", function () {
+            expect(scope.startCreateDiscoveryView).toBeDefined();
+            expect(typeof scope.startCreateDiscoveryView).toEqual("function");
+        });
+        it("startUpdateDiscoveryView should be defined", function () {
+            expect(scope.startUpdateDiscoveryView).toBeDefined();
+            expect(typeof scope.startUpdateDiscoveryView).toEqual("function");
+        });
+        it("updateDiscoveryView should be defined", function () {
+            expect(scope.updateDiscoveryView).toBeDefined();
+            expect(typeof scope.updateDiscoveryView).toEqual("function");
+        });
+    });
+
+    describe("Do the scope methods work as expected", function () {
+        it("appendSearchFieldItem should work", function () {
+            var result;
+
+            result = scope.appendSearchFieldItem();
+            // @todo
+        });
+        it("cancelCreateDiscoveryView should work", function () {
+            var result;
+
+            result = scope.cancelCreateDiscoveryView();
+            // @todo
+        });
+        it("cancelDeleteDiscoveryView should work", function () {
+            var result;
+
+            result = scope.cancelDeleteDiscoveryView();
+            // @todo
+        });
+        it("cancelUpdateDiscoveryView should work", function () {
+            var result;
+
+            result = scope.cancelUpdateDiscoveryView();
+            // @todo
+        });
+        it("confirmDeleteDiscoveryView should work", function () {
+            var result;
+
+            result = scope.confirmDeleteDiscoveryView();
+            // @todo
+        });
+        it("createDiscoveryView should work", function () {
+            var result;
+
+            result = scope.createDiscoveryView();
+            // @todo
+        });
+        it("deleteDiscoveryView should work", function () {
+            var result;
+
+            result = scope.deleteDiscoveryView();
+            // @todo
+        });
+        it("findFieldByKey should work", function () {
+            var result;
+
+            result = scope.findFieldByKey();
+            // @todo
+        });
+        it("getFields should work", function () {
+            var result;
+
+            result = scope.getFields();
+            // @todo
+        });/*
+        it("isDiscoveryViewFacetsInvalid should work", function () {
+            var result;
+
+            result = scope.isDiscoveryViewFacetsInvalid("create");
+            // @todo
+        });
+        it("isDiscoveryViewGeneralInvalid should work", function () {
+            var result;
+
+            result = scope.isDiscoveryViewGeneralInvalid("create");
+            // @todo
+        });
+        it("isDiscoveryViewResultsInvalid should work", function () {
+            var result;
+
+            result = scope.isDiscoveryViewResultsInvalid("create");
+            // @todo
+        });
+        it("isDiscoveryViewSearchInvalid should work", function () {
+            var result;
+
+            result = scope.isDiscoveryViewSearchInvalid("create");
+            // @todo
+        });*/
+        it("resetDiscoveryViewForms should work", function () {
+            var result;
+
+            result = scope.resetDiscoveryViewForms();
+            // @todo
+        });
+        it("startCreateDiscoveryView should work", function () {
+            var result;
+
+            result = scope.startCreateDiscoveryView();
+            // @todo
+        });
+        it("startUpdateDiscoveryView should work", function () {
+            var result;
+            var dv = new mockDiscoveryView(q);
+
+            result = scope.startUpdateDiscoveryView(dv);
+            // @todo
+        });
+        /*
+        it("updateDiscoveryView should work", function () {
+            var result;
+
+            result = scope.updateDiscoveryView();
+            // @todo
+        });
+        */
+    });
+
+});

--- a/src/main/webapp/tests/unit/models/discoveryContextModelTest.js
+++ b/src/main/webapp/tests/unit/models/discoveryContextModelTest.js
@@ -1,0 +1,102 @@
+describe('model: DiscoveryContext', function () {
+    var model, rootScope, scope, location, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $rootScope, _WsApi_) {
+            location = $location;
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (DiscoveryContext) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new DiscoveryContext(), dataDiscoveryContext1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+
+    describe('Are the model methods defined', function () {
+        it('clearFilters should be defined', function () {
+            expect(model.clearFilters).toBeDefined();
+            expect(typeof model.clearFilters).toEqual("function");
+        });
+        it('executeSearch should be defined', function () {
+            expect(model.executeSearch).toBeDefined();
+            expect(typeof model.executeSearch).toEqual("function");
+        });
+        it('isSearching should be defined', function () {
+            expect(model.isSearching).toBeDefined();
+            expect(typeof model.isSearching).toEqual("function");
+        });
+        it('reload should be defined', function () {
+            expect(model.reload).toBeDefined();
+            expect(typeof model.reload).toEqual("function");
+        });
+        it('removeFilter should be defined', function () {
+            expect(model.removeFilter).toBeDefined();
+            expect(typeof model.removeFilter).toEqual("function");
+        });
+        it('setSearchField should be defined', function () {
+            expect(model.setSearchField).toBeDefined();
+            expect(typeof model.setSearchField).toEqual("function");
+        });
+    });
+
+    describe('Are the model methods working as expected', function () {
+        it('clearFilters should work', function () {
+            spyOn(model, 'executeSearch');
+
+            model.clearFilters();
+            scope.$digest();
+
+            expect(model.executeSearch).toHaveBeenCalled();
+        });
+        it('executeSearch should work', function () {
+            spyOn(location, 'search');
+
+            // @todo: more work needed here.
+            model.executeSearch();
+            scope.$digest();
+
+            expect(location.search).toHaveBeenCalled();
+        });
+        it('isSearching should work', function () {
+            // @todo
+            model.isSearching();
+            scope.$digest();
+        });
+        it('reload should work', function () {
+            // @todo
+            model.reload();
+            scope.$digest();
+        });
+        it('removeFilter should work', function () {
+            // @todo
+            model.removeFilter();
+            scope.$digest();
+        });
+        it('setSearchField should work', function () {
+            // @todo
+            model.setSearchField();
+            scope.$digest();
+        });
+    });
+});

--- a/src/main/webapp/tests/unit/models/discoveryViewModelTest.js
+++ b/src/main/webapp/tests/unit/models/discoveryViewModelTest.js
@@ -1,0 +1,35 @@
+describe('model: DiscoveryView', function () {
+    var model, rootScope, scope, location, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $rootScope, _WsApi_) {
+            location = $location;
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (DiscoveryView) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new DiscoveryView(), dataDiscoveryView1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+});

--- a/src/main/webapp/tests/unit/models/fieldModelTest.js
+++ b/src/main/webapp/tests/unit/models/fieldModelTest.js
@@ -1,0 +1,35 @@
+describe('model: Field', function () {
+    var model, rootScope, scope, location, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $rootScope, _WsApi_) {
+            location = $location;
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (Field) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new Field(), dataField1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+});

--- a/src/main/webapp/tests/unit/models/resultModelTest.js
+++ b/src/main/webapp/tests/unit/models/resultModelTest.js
@@ -1,0 +1,35 @@
+describe('model: Result', function () {
+    var model, rootScope, scope, location, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $rootScope, _WsApi_) {
+            location = $location;
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (Result) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new Result(), dataResult1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+});

--- a/src/main/webapp/tests/unit/models/searchFieldModelTest.js
+++ b/src/main/webapp/tests/unit/models/searchFieldModelTest.js
@@ -1,0 +1,34 @@
+describe('model: SearchField', function () {
+    var model, rootScope, scope, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($rootScope, _WsApi_) {
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (SearchField) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new SearchField(), dataSearchField1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+});

--- a/src/main/webapp/tests/unit/models/searchModelTest.js
+++ b/src/main/webapp/tests/unit/models/searchModelTest.js
@@ -1,0 +1,34 @@
+describe('model: Search', function () {
+    var model, rootScope, scope, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($rootScope, _WsApi_) {
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (Search) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new Search(), dataSearch1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+});

--- a/src/main/webapp/tests/unit/models/singleResultContextModelTest.js
+++ b/src/main/webapp/tests/unit/models/singleResultContextModelTest.js
@@ -1,0 +1,35 @@
+describe('model: SingleResultContext', function () {
+    var model, rootScope, scope, location, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $rootScope, _WsApi_) {
+            location = $location;
+            rootScope = $rootScope;
+
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeModel = function(settings) {
+        inject(function (SingleResultContext) {
+            scope = rootScope.$new();
+
+            model = angular.extend(new SingleResultContext(), dataSingleResultContext1);
+        });
+    };
+
+    beforeEach(function() {
+        module('core');
+        module('sage');
+        module('mock.wsApi');
+
+        initializeVariables();
+        initializeModel();
+    });
+
+    describe('Is the model defined', function () {
+        it('should be defined', function () {
+            expect(model).toBeDefined();
+        });
+    });
+});


### PR DESCRIPTION
Refactor discovery views design, using Solr classes instead of custom generating a solr query string.
The `buildSearch()` from SolrDiscoveryService.java has been completely removed.

Provide a custom search field to be used as a Solr "q" and redesign the facets to operate as "facet" and "facet.field".
The custom search field supports ordering, but no ordering is implemented at this time.

The parameters for `findBySlug()` have been changed such that:
- Now using Pageable, which uses "page", "sort", and "size" (and paves the way for potential multiple sort-by parameters).
- Added custom "offset" parameter to maintain current position when the limit (size) is changed.
- The query is now explicitly broken up into two parameters "field" and "value", and an empty field designates "search_all".

The Search response class has been simplified to only return informative properties: field, start, and total.
The "field" property tells the front-end what the field is so that the idea of an "all_fields" can be treated as an empty string.
It may be a good idea to use an empty string in all cases for the "all_fields" instead of the string "all_fields".

Fixed typos such as `getSinlgeResult` and `previouse`.

Search parameters, such as the search value text box, are now preserved more consistently.
Use controller methods instead of directly calling `discoveryContext.executeSearch()` in the `discovery-context.html` view.

Strip default parameters from the url bar query parameters, keeping it as short as reasonably possible.

When pagination position is too large after a search update, adjust the position.
