### PR TITLE
Defect 01287: Record facet fields in URL bar, making discovery results deep-linkable

### DIFF
--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -73,12 +73,16 @@ public class SolrDiscoveryService {
 
                 String filterKey = "f." + facetField.getKey();
                 if (filterMap.containsKey(filterKey)) {
-                    Filter filter = new Filter();
-                    filter.setKey(facetField.getKey());
-                    filter.setLabel(facetField.getLabel());
-                    filter.setValue(filterMap.get(filterKey));
-                    filters.add(filter);
-                    solrQuery.addFilterQuery(facetField.getKey() + ":" + filterMap.get(filterKey));
+                    String[] filterValues = filterMap.get(filterKey).split(",", -1);
+
+                    for (int i = 0; i < filterValues.length; i++) {
+                        Filter filter = new Filter();
+                        filter.setKey(facetField.getKey());
+                        filter.setLabel(facetField.getLabel());
+                        filter.setValue(filterValues[i]);
+                        filters.add(filter);
+                        solrQuery.addFilterQuery(facetField.getKey() + ":" + filterValues[i]);
+                    }
                 }
             });
 

--- a/src/main/webapp/app/model/discoveryContextModel.js
+++ b/src/main/webapp/app/model/discoveryContextModel.js
@@ -41,15 +41,15 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
     discoveryContext.before(function () {
       var filters = [];
 
-      if ($routeParams.filters) {
-        angular.forEach($routeParams.filters, function(v, k) {
+      angular.forEach($routeParams, function(value, key) {
+        if (key.match(/^f\./i)) {
           var filter = {
-            key: k,
-            value: v
+            key: key.replace(/^f\./, ""),
+            value: value
           };
           filters.push(filter);
-        });
-      }
+        }
+      });
 
       discoveryContext.search = new Search({
         field: angular.isDefined($routeParams.field) ? $routeParams.field : "",
@@ -76,6 +76,7 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
           discoveryContext.search.page.number = page;
           $location.search("page", discoveryContext.search.page.number);
         }
+
         discoveryContext.search.field = search.field;
         discoveryContext.search.filters = search.filters ? search.filters : [];
         discoveryContext.search.start = search.start;
@@ -110,6 +111,11 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
       }
 
       discoveryContext.search.filters.push(filter);
+
+      var urlKey = "f." + filter.key;
+      var existingValues = discoveryContext.buildUrlFilterKeyValues();
+
+      $location.search(urlKey, existingValues[urlKey]);
       return discoveryContext.executeSearch();
     };
 
@@ -118,13 +124,30 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
         var f = discoveryContext.search.filters[i];
         if (f.key === filter.key && f.value === filter.value) {
           discoveryContext.search.filters.splice(i, 1);
+
+          var urlKey = "f." + filter.key;
+          var existingValues = discoveryContext.buildUrlFilterKeyValues();
+
+          if (existingValues && angular.isDefined(existingValues[urlKey])) {
+            $location.search(urlKey, existingValues[urlKey]);
+          } else {
+            $location.search(urlKey, null);
+          }
+
+          break;
         }
       }
+
       return discoveryContext.executeSearch();
     };
 
     discoveryContext.clearFilters = function() {
       discoveryContext.search.filters.length = 0;
+
+      angular.forEach($location.search(), function(value, key) {
+        if (key.match(/^f\./i)) $location.search(key, null);
+      });
+
       return discoveryContext.executeSearch();
     };
 
@@ -143,7 +166,6 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
             $location.search("sort", null);
             $location.search("size", null);
             $location.search("offset", null);
-            $location.search("filters", null);
           }
 
           discoveryContext.reload().then(function() {
@@ -154,12 +176,39 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, WsApi, Res
             $location.search("sort", discoveryContext.search.page.sort === defaultPageSort ? null : discoveryContext.search.page.sort);
             $location.search("size", discoveryContext.search.page.size === defaultPageSize ? null : discoveryContext.search.page.size);
             $location.search("offset", discoveryContext.search.page.offset === 0 ? null : discoveryContext.search.page.offset);
+
+            if (discoveryContext.search.filters) {
+              angular.forEach(discoveryContext.buildUrlFilterKeyValues(), function(value, key) {
+                $location.search(key, value);
+              });
+            }
+
             resolve();
           });
         } else {
           resolve();
         }
       });
+    };
+
+    discoveryContext.buildUrlFilterKeyValues = function() {
+      var filtersByKey;
+
+      if (discoveryContext.search.filters.length > 0) {
+        filtersByKey = {};
+
+        angular.forEach(discoveryContext.search.filters, function(filter) {
+          var urlKey = "f." + filter.key;
+
+          if (!angular.isDefined(filtersByKey[urlKey])) {
+            filtersByKey[urlKey] = [];
+          }
+
+          filtersByKey[urlKey].push(filter.value);
+        });
+      }
+
+      return filtersByKey;
     };
 
     discoveryContext.isSearching = function() {

--- a/src/main/webapp/tests/mocks/model/mockFilter.js
+++ b/src/main/webapp/tests/mocks/model/mockFilter.js
@@ -1,0 +1,28 @@
+var dataFilter1 = {
+  id: 1,
+  key: "key1",
+  label: "Filter 1",
+  value: "Value 1"
+};
+
+var dataFilter2 = {
+  id: 2,
+  key: "key2",
+  label: "Filter 2",
+  value: "Value 2"
+};
+
+var dataFilter3 = {
+  id: 3,
+  key: "key1",
+  label: "Filter 3, with key1",
+  value: "Value 3"
+};
+
+var mockFilter = function($q) {
+  var model = mockModel("Filter", $q, dataFilter1);
+
+  return model;
+};
+
+angular.module("mock.filter", []).service("Filter", mockFilter);

--- a/src/main/webapp/tests/mocks/services/mockWsApi.js
+++ b/src/main/webapp/tests/mocks/services/mockWsApi.js
@@ -25,7 +25,7 @@ angular.module('mock.wsApi', []).service('WsApi', function ($q) {
     }
   };
 
-  service.fetch = function (apiReq) {
+  service.fetch = function (apiReq, parameters) {
     var payload = {};
 
     if (fetchResponse) {

--- a/src/main/webapp/tests/unit/models/discoveryContextModelTest.js
+++ b/src/main/webapp/tests/unit/models/discoveryContextModelTest.js
@@ -1,13 +1,34 @@
 describe('model: DiscoveryContext', function () {
-  var model, rootScope, scope, location, WsApi;
+  var model, rootScope, routeParams, scope, location, wsResponse, WsApi;
 
   var initializeVariables = function(settings) {
-    inject(function ($q, $location, $rootScope, _WsApi_) {
+    inject(function ($q, $location, $rootScope, $routeParams, _WsApi_) {
       location = $location;
       q = $q;
       rootScope = $rootScope;
+      routeParams = settings && settings.routeParams ? settings.routeParams : $routeParams;
 
       WsApi = _WsApi_;
+
+      wsResponse = {
+        type: "payload",
+        payload: {
+          DiscoveryContext: {
+            search: {
+              field: "",
+              value: "",
+              page: {
+                sort: "id",
+                number: 0,
+                size: 10,
+                offset: 0
+              }
+            }
+          }
+        }
+      };
+
+      WsApi.mockFetchResponse(wsResponse);
     });
   };
 
@@ -16,18 +37,25 @@ describe('model: DiscoveryContext', function () {
       scope = rootScope.$new();
 
       model = angular.extend(new DiscoveryContext(), dataDiscoveryContext1);
+
+      // ensure that the isReady() is called.
+      if (!scope.$$phase) {
+        scope.$digest();
+      }
     });
   };
 
   beforeEach(function() {
     module('core');
     module('sage');
+    module('mock.filter');
     module('mock.wsApi');
 
     initializeVariables();
     initializeModel();
   });
 
+  // @todo: discoveryContext.before() needs to be tested as well.
   describe('Is the model defined', function () {
     it('should be defined', function () {
       expect(model).toBeDefined();
@@ -35,6 +63,21 @@ describe('model: DiscoveryContext', function () {
   });
 
   describe('Are the model methods defined', function () {
+    it('addFilter should be defined', function () {
+      expect(model.addFilter).toBeDefined();
+      expect(typeof model.addFilter).toEqual("function");
+    });
+
+    it('buildPage should be defined', function () {
+      expect(model.buildPage).toBeDefined();
+      expect(typeof model.buildPage).toEqual("function");
+    });
+
+    it('buildUrlFilterKeyValues should be defined', function () {
+      expect(model.buildUrlFilterKeyValues).toBeDefined();
+      expect(typeof model.buildUrlFilterKeyValues).toEqual("function");
+    });
+
     it('clearFilters should be defined', function () {
       expect(model.clearFilters).toBeDefined();
       expect(typeof model.clearFilters).toEqual("function");
@@ -67,108 +110,178 @@ describe('model: DiscoveryContext', function () {
   });
 
   describe('Are the model methods working as expected', function () {
-    it('clearFilters should work', function () {
-      var payload = {
-        payload: {
-          DiscoveryContext: {}
-        }
-      };
-
-      WsApi.fetch = function() {
-        return payloadPromise(q.defer(), payload);
-      };
+    it('addFilter should work', function () {
+      var mockFilter1 = new mockFilter(q);
+      var mockFilter2 = new mockFilter(q);
+      var mockFilter3 = new mockFilter(q);
+      mockFilter2.mock(dataFilter2);
+      mockFilter3.mock(dataFilter3);
 
       spyOn(model, 'executeSearch');
+      delete model.search.filters;
 
-      //model.clearFilters();
-      //scope.$digest();
+      model.addFilter(mockFilter1.label, mockFilter1.key, mockFilter1.value);
+      scope.$digest();
 
-      //expect(model.executeSearch).toHaveBeenCalled();
+      expect(model.search.filters.length).toBe(1);
+      expect(model.executeSearch).toHaveBeenCalled();
+
+      model.addFilter(mockFilter2.label, mockFilter2.key, mockFilter2.value);
+      scope.$digest();
+      expect(model.search.filters.length).toBe(2);
+
+      model.addFilter(mockFilter3.label, mockFilter3.key, mockFilter3.value);
+      scope.$digest();
+      expect(model.search.filters.length).toBe(3);
+    });
+
+    it('buildPage should work', function () {
+      var page;
+
+      // @todo: need to alter $routeParams and test different values.
+      page = model.buildPage();
+
+      expect(page.number).toBe(0);
+      expect(page.offset).toBe(0);
+    });
+
+    it('buildUrlFilterKeyValues should work', function () {
+      var urlFilters;
+      var mockFilter1 = new mockFilter(q);
+      var mockFilter2 = new mockFilter(q);
+      var mockFilter3 = new mockFilter(q);
+      mockFilter2.mock(dataFilter2);
+      mockFilter3.mock(dataFilter3);
+
+      model.search.filters = [];
+
+      urlFilters = model.buildUrlFilterKeyValues();
+      expect(urlFilters).not.toBeDefined();
+
+      model.search.filters.push(mockFilter1);
+      urlFilters = model.buildUrlFilterKeyValues();
+      expect(urlFilters["f." + mockFilter1.key]).toBeDefined();
+      expect(urlFilters["f." + mockFilter1.key].length).toBe(1);
+
+      model.search.filters.push(mockFilter2);
+      urlFilters = model.buildUrlFilterKeyValues();
+      expect(urlFilters["f." + mockFilter2.key]).toBeDefined();
+      expect(urlFilters["f." + mockFilter2.key].length).toBe(1);
+
+      // mockFilter3 should have same key as mockFilter1.
+      model.search.filters.push(mockFilter3);
+      urlFilters = model.buildUrlFilterKeyValues();
+      expect(urlFilters["f." + mockFilter3.key]).toBeDefined();
+      expect(urlFilters["f." + mockFilter1.key].length).toBe(2);
+    });
+
+    it('clearFilters should work', function () {
+      var mockFilter1 = new mockFilter(q);
+      var mockFilter2 = new mockFilter(q);
+      mockFilter2.mock(dataFilter2);
+
+      spyOn(model, 'executeSearch');
+      model.search.filters = [ mockFilter1, mockFilter2 ];
+      location.search("f.mock", "mockedValue");
+
+      model.clearFilters();
+      scope.$digest();
+
+      expect(model.search.filters.length).toBe(0);
+      expect(model.executeSearch).toHaveBeenCalled();
     });
 
     it('executeSearch should work', function () {
-      var payload = {
-        payload: {
-          DiscoveryContext: {}
-        }
-      };
+      var originalSearch = location.search;
+      spyOn(location, 'search').and.callThrough();
 
-      WsApi.fetch = function() {
-        return payloadPromise(q.defer(), payload);
-      };
+      model.executeSearch(false);
+      scope.$digest();
 
-      spyOn(location, 'search');
+      expect(location.search).toHaveBeenCalled();
 
-      // @todo: more work needed here.
-      //model.executeSearch();
-      //scope.$digest();
+      wsResponse.payload.DiscoveryContext.search.field = "mockField";
+      wsResponse.payload.DiscoveryContext.search.value = "mockValue";
+      wsResponse.payload.DiscoveryContext.search.page.number = 1;
+      wsResponse.payload.DiscoveryContext.search.page.sort = "id";
+      wsResponse.payload.DiscoveryContext.search.page.size = -1;
+      wsResponse.payload.DiscoveryContext.search.page.offset = -1;
+      wsResponse.payload.DiscoveryContext.search.filters = [ "f.mock1", "f.mock2" ];
+      location.search = originalSearch;
+      spyOn(location, 'search').and.callThrough();
 
-      //expect(location.search).toHaveBeenCalled();
+      model.executeSearch(true);
+      scope.$digest();
+
+      expect(location.search).toHaveBeenCalled();
+
+      // searching cannot be directly assigned, but it gets assigned when executeSearch() is called.
+      // because $digest() has likely not yet happened, the second call will likely trigger the "!searching" case.
+      model.executeSearch();
+      model.executeSearch();
+      scope.$digest();
     });
 
     it('isSearching should work', function () {
-      var payload = {
-        payload: {
-          DiscoveryContext: {}
-        }
-      };
+      model.executeSearch();
+      expect(model.isSearching()).toBe(true);
+      scope.$digest();
 
-      WsApi.fetch = function() {
-        return payloadPromise(q.defer(), payload);
-      };
-
-      // @todo
-      //model.isSearching();
-      //scope.$digest();
+      expect(model.isSearching()).toBe(false);
     });
 
     it('reload should work', function () {
-      var payload = {
-        payload: {
-          DiscoveryContext: {}
-        }
+      wsResponse.payload.DiscoveryContext.search.field = "mock";
+      wsResponse.payload.DiscoveryContext.search.filters = {
+        "f.mock1": "value1",
+        "f.mock2": "value2",
       };
 
-      WsApi.fetch = function() {
-          return payloadPromise(q.defer(), payload);
-      };
+      model.reload();
+      scope.$digest();
+      expect(model.search.field).toBe("mock");
 
-      // @todo
-      //model.reload();
-      //scope.$digest();
+      wsResponse.payload.DiscoveryContext.search.page = 1;
+      model.reload();
+      scope.$digest();
+
+      expect(model.search.page.number).toBe(1);
     });
 
     it('removeFilter should work', function () {
-      var payload = {
-        payload: {
-          DiscoveryContext: {}
-        }
-      };
+      var mockFilter1 = new mockFilter(q);
+      var mockFilter2 = new mockFilter(q);
+      var mockFilter3 = new mockFilter(q);
+      mockFilter2.mock(dataFilter2);
+      mockFilter3.mock(dataFilter3);
 
-      WsApi.fetch = function() {
-        return payloadPromise(q.defer(), payload);
-      };
+      spyOn(model, 'executeSearch');
+      model.search.filters = [ mockFilter1, mockFilter2, mockFilter3 ];
 
-      // @todo
-      //model.removeFilter();
-      //scope.$digest();
+      model.removeFilter(mockFilter2);
+      scope.$digest();
+
+      expect(model.search.filters.length).toBe(2);
+      expect(model.executeSearch).toHaveBeenCalled();
+
+      model.removeFilter(mockFilter1);
+      scope.$digest();
+      expect(model.search.filters.length).toBe(1);
+
+      model.removeFilter(mockFilter3);
+      scope.$digest();
+      expect(model.search.filters.length).toBe(0);
     });
 
     it('setSearchField should work', function () {
-      // todo: spyOn(WsApi, "fetch").and.returnValue(defer.promise);
-      var payload = {
-        payload: {
-          DiscoveryContext: {}
-        }
-      };
+      var searchField = new mockSearchField(q);
+      model.search.field = "";
+      model.search.value = "";
 
-      WsApi.fetch = function() {
-        return payloadPromise(q.defer(), payload);
-      };
+      model.setSearchField(searchField.key, searchField.value);
 
-      // @todo
-      //model.setSearchField();
-      //scope.$digest();
+      expect(model.search.field).toBe(searchField.key);
+      expect(model.search.value).toBe(searchField.value);
     });
   });
 


### PR DESCRIPTION
Filters from the route parameters are prefixed with "f.".
The parameter "filters" is no longer used.

When assigning multiple values to a single URL parameter field in `$location.search()`, an array needs to be used.

The parameters are received in the backend as a comma separated list.
If this list is not split into an array, then the wrong structure will be sent down.
The wrong structure would be something like `texan,narrative`, which should instead be two distinct values `texan`, and `narrative`.