### PR TITLE
[B-03977] Boolean to toggle "filter" as being required on a per-core basis

### DIFF
--- a/src/main/java/edu/tamu/sage/model/Sourcable.java
+++ b/src/main/java/edu/tamu/sage/model/Sourcable.java
@@ -14,4 +14,6 @@ public interface Sourcable {
     public String getPassword();
     public void setPassword(String password);
 
+    public Boolean getRequiresFilter();
+    public void setRequiresFilter(Boolean requiresFilter);
 }

--- a/src/main/java/edu/tamu/sage/model/Source.java
+++ b/src/main/java/edu/tamu/sage/model/Source.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.tamu.sage.model.validation.SourceValidator;
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 
+
+// In the UI, this is called a "Core" and not a "Source", the "readOnly" property instead designates this as a "Source" or "Destination".
 @Entity
 public class Source extends ValidatingBaseEntity implements Sourcable {
     //TODO Query the SOLR Core for its fields to provide Readers/Writers with a list of fields to choose from for mapping to the internal metadata fields
@@ -29,20 +31,27 @@ public class Source extends ValidatingBaseEntity implements Sourcable {
     @JsonIgnore
     private String password;
 
+    // In the UI, this is used as the "Type", such that TRUE is "Source", and FALSE is "Destination".
     @NotNull
     @Column(nullable = false)
     private Boolean readOnly;
+
+    @NotNull
+    @Column(nullable = false)
+    private Boolean requiresFilter;
 
     public Source() {
         setModelValidator(new SourceValidator());
     }
 
-    public Source(String name, String uri, String username, String password) {
+    public Source(String name, String uri, String username, String password, Boolean readOnly, Boolean requiresFilter) {
         this();
         setName(name);
         setUri(uri);
         setUsername(username);
         setPassword(password);
+        setReadOnly(readOnly);
+        setRequiresFilter(requiresFilter);
     }
 
     @Override
@@ -91,5 +100,15 @@ public class Source extends ValidatingBaseEntity implements Sourcable {
 
     public void setReadOnly(Boolean readOnly) {
         this.readOnly = readOnly;
+    }
+
+    @Override
+    public Boolean getRequiresFilter() {
+        return requiresFilter;
+    }
+
+    @Override
+    public void setRequiresFilter(Boolean requiresFilter) {
+        this.requiresFilter = requiresFilter;
     }
 }

--- a/src/main/java/edu/tamu/sage/model/validation/DiscoveryViewValidator.java
+++ b/src/main/java/edu/tamu/sage/model/validation/DiscoveryViewValidator.java
@@ -8,18 +8,15 @@ public class DiscoveryViewValidator extends BaseModelValidator {
     public DiscoveryViewValidator() {
         String nameProperty = "name";
         this.addInputValidator(new InputValidator(InputValidationType.required, "A Discovery View requires a name", nameProperty, true));
-        
+
         String sourceProperty = "source";
         this.addInputValidator(new InputValidator(InputValidationType.required, "A Discovery View requires a source", sourceProperty, true));
-        
-        String filterProperty = "filter";
-        this.addInputValidator(new InputValidator(InputValidationType.required, "A Discovery View requires a filter", filterProperty, true));
-        
+
         String slugProperty = "slug";
         this.addInputValidator(new InputValidator(InputValidationType.required, "A Discovery View requires a slug", slugProperty, true));
-        
+
         String primaryKeyProperty = "titleKey";
         this.addInputValidator(new InputValidator(InputValidationType.required, "A Discovery View requires a Title Key", primaryKeyProperty, true));
-        
+
     }
 }

--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -36,6 +36,8 @@ import edu.tamu.sage.utility.ValueTemplateUtility;
 @Service
 public class SolrDiscoveryService {
 
+    private final static String FILTER_WILDCARD = "*:*";
+
     private final static Logger logger = LoggerFactory.getLogger(SolrDiscoveryService.class);
 
     @Autowired
@@ -57,7 +59,7 @@ public class SolrDiscoveryService {
 
         search.setField(field.equalsIgnoreCase(ALL_FIELDS_KEY) ? "" : field);
 
-        String query = "*:*";
+        String query = FILTER_WILDCARD;
         if (!(field.isEmpty() || value.isEmpty())) {
             query = search.getField();
             query += ":" + (value.isEmpty() ? "*" : value);
@@ -113,6 +115,9 @@ public class SolrDiscoveryService {
     public List<SolrField> getAvailableFields(DiscoveryView discoveryView) throws DiscoveryContextBuildException {
         String uri = discoveryView.getSource().getUri();
         String filter = discoveryView.getFilter();
+        if (discoveryView.getSource().getRequiresFilter() && filter.isEmpty()) {
+            filter = FILTER_WILDCARD;
+        }
         try {
             return solrSourceService.getAvailableFields(uri, filter);
         } catch (SourceServiceException e) {

--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -132,7 +132,8 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
 
   $scope.getFields = function(dv) {
     if (angular.isDefined(dv)) {
-      $scope.fields = SourceRepo.getAvailableFields(dv.source.uri, dv.filter);
+      var filter = dv.filter.length == 0 && dv.source.requiresFilter ? "*.*" : dv.filter;
+      $scope.fields = SourceRepo.getAvailableFields(dv.source.uri, filter);
     }
   };
 

--- a/src/main/webapp/app/controllers/management/sourceManagementController.js
+++ b/src/main/webapp/app/controllers/management/sourceManagementController.js
@@ -1,3 +1,4 @@
+// This managers "Cores", to represent a "Source", the readOnly property of a "Core" needs to be set to TRUE.
 sage.controller('SourceManagementController', function ($controller, $scope, NgTableParams, SourceRepo) {
 
   angular.extend(this, $controller('AbstractController', {

--- a/src/main/webapp/app/model/sourceModel.js
+++ b/src/main/webapp/app/model/sourceModel.js
@@ -1,3 +1,4 @@
+// This relates to a "Core", to represent a "Source", the readOnly property of a "Core" needs to be set to TRUE.
 sage.model("Source", function(WsApi, HttpMethodVerbs) {
   return function Source() {
     var core = this;

--- a/src/main/webapp/app/repo/discoveryViewRepo.js
+++ b/src/main/webapp/app/repo/discoveryViewRepo.js
@@ -5,7 +5,7 @@ sage.repo("DiscoveryViewRepo", function() {
     name: "",
     source: "",
     facetFields: [],
-    filter: "*:*",
+    filter: "",
     resourceLocationUriKey: "",
     resourceThumbnailUriKey: "",
     resultMetadataFields: [],

--- a/src/main/webapp/app/repo/sourceRepo.js
+++ b/src/main/webapp/app/repo/sourceRepo.js
@@ -1,3 +1,4 @@
+// This managers "Cores", to represent a "Source", the readOnly property of a "Core" needs to be set to TRUE.
 sage.repo("SourceRepo", function (Source, WsApi) {
   var sourceRepo = this;
 
@@ -5,6 +6,7 @@ sage.repo("SourceRepo", function (Source, WsApi) {
     name: "Local Solr",
     uri: "http://localhost:8983/solr/collection1",
     readOnly: true,
+    requiresFilter: true,
     username: "",
     password: ""
   });

--- a/src/main/webapp/app/views/modals/createSourceModal.html
+++ b/src/main/webapp/app/views/modals/createSourceModal.html
@@ -11,6 +11,7 @@
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
             <validatedinput
+              id="sourceToCreateName"
               model="sourceToCreate"
               property="name"
               label="Name"
@@ -22,6 +23,7 @@
             </validatedinput>
 
             <validatedinput
+              id="sourceToCreateUri"
               model="sourceToCreate"
               property="uri"
               label="URI"
@@ -31,15 +33,30 @@
               results="sourceForms.getResults()"
               autocomplete="off">
             </validatedinput>
-            <div>
-              <label>Type</label>
+
+            <div class="form-group">
+              <div>
+                <label id="sourceToCreateReadOnlyLabel">Type</label>
+              </div>
+              <label class="radio-inline" role="group" aria-labelledby="sourceToCreateReadOnlyLabel">
+                <input type="radio" name="sourceToCreateReadOnly" ng-model="sourceToCreate.readOnly" ng-value="true"> Source
+              </label>
+              <label class="radio-inline" role="group" aria-labelledby="sourceToCreateReadOnlyLabel">
+                <input type="radio" name="sourceToCreateReadOnly" ng-model="sourceToCreate.readOnly" ng-value="false"> Destination
+              </label>
             </div>
-            <label class="radio-inline">
-              <input type="radio" name="sourceToCreateReadOnly" ng-model="sourceToCreate.readOnly" ng-value="true"> Source
-            </label>
-            <label class="radio-inline">
-              <input type="radio" name="sourceToCreateReadOnly" ng-model="sourceToCreate.readOnly" ng-value="false"> Destination
-            </label>
+
+            <validatedinput
+              id="sourceToCreateRequiresFilter"
+              type="checkbox"
+              model="sourceToCreate"
+              property="requiresFilter"
+              label="Requires Filter"
+              form="sourceForms.create"
+              validations="sourceForms.validations"
+              results="sourceForms.getResults()"
+              autocomplete="off">
+            </validatedinput>
           </div>
         </div>
       </uib-tab>
@@ -56,7 +73,6 @@
                 results="sourceForms.getResults()"
                 autocomplete="off">
               </validatedinput>
-
 
               <validatedinput
                 model="sourceToCreate"

--- a/src/main/webapp/app/views/modals/updateSourceModal.html
+++ b/src/main/webapp/app/views/modals/updateSourceModal.html
@@ -11,6 +11,7 @@
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
             <validatedinput
+              id="sourceToUpdateName"
               model="sourceToUpdate"
               property="name"
               label="Name"
@@ -22,6 +23,7 @@
             </validatedinput>
 
             <validatedinput
+              id="sourceToUpdateUri"
               model="sourceToUpdate"
               property="uri"
               label="URI"
@@ -31,10 +33,23 @@
               results="sourceForms.getResults()"
               autocomplete="off">
             </validatedinput>
+
             <div class="input-group">
               <label>Type</label>
               <input class="form-control" type="text" name="sourceToUpdateReadOnly" value="{{sourceToUpdate.readOnly ? 'Source':'Destination'}}" readonly>
             </div>
+
+            <validatedinput
+              id="sourceToUpdateRequiresFilter"
+              type="checkbox"
+              model="sourceToUpdate"
+              property="requiresFilter"
+              label="Requires Filter"
+              form="sourceForms.update"
+              validations="sourceForms.validations"
+              results="sourceForms.getResults()"
+              autocomplete="off">
+            </validatedinput>
           </div>
         </div>
       </uib-tab>
@@ -42,6 +57,7 @@
           <div class="row">
             <div class="col-sm-10 col-sm-offset-1">
               <validatedinput
+                id="sourceToUpdateUsername"
                 model="sourceToUpdate"
                 property="username"
                 label="User Name"
@@ -53,6 +69,7 @@
               </validatedinput>
 
               <validatedinput
+                id="sourceToUpdatePassword"
                 model="sourceToUpdate"
                 property="password"
                 label="Password"

--- a/src/main/webapp/tests/mocks/model/mockSource.js
+++ b/src/main/webapp/tests/mocks/model/mockSource.js
@@ -4,7 +4,8 @@ var dataSource1 = {
   uri: "cap.library.tamu.edu",
   username: null,
   password: null,
-  readOnly: false
+  readOnly: true,
+  requiresFilter: true
 };
 
 var dataSource2 = {
@@ -13,7 +14,8 @@ var dataSource2 = {
   uri: "cap.library.tamu.edu",
   username: null,
   password: null,
-  readOnly: false
+  readOnly: true,
+  requiresFilter: false
 };
 
 var dataSource3 = {
@@ -22,7 +24,8 @@ var dataSource3 = {
   uri: "cap.library.tamu.edu",
   username: "4253938752821",
   password: "1425393875282",
-  readOnly: false
+  readOnly: false,
+  requiresFilter: true
 };
 
 var mockSource = function($q) {

--- a/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
@@ -23,7 +23,7 @@ angular.module("mock.discoveryViewRepo", []).service("DiscoveryViewRepo", functi
     name: "",
     source: "",
     facetFields: [],
-    filter: "*:*",
+    filter: "",
     resourceLocationUriKey: "",
     resourceThumbnailUriKey: "",
     resultMetadataFields: [],

--- a/src/main/webapp/tests/mocks/repo/mockSourceRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockSourceRepo.js
@@ -23,6 +23,7 @@ angular.module("mock.sourceRepo", []).service("SourceRepo", function($q) {
     name: "Local Solr",
     uri: "http://localhost:8983/solr/collection1",
     readOnly: true,
+    requiresFilter: true,
     username: "",
     password: ""
   };


### PR DESCRIPTION
When the boolean "requiresFilter" is TRUE, and the "filter" property on a Discovery View is empty, then use "*.*" for Discovery View.
Where Filter is not allowed to be "*.*", the "requiresFilter" can be set to FALSE.

This fixes structural an accessibility issues with the `sourceToCreate.readOnly` field tag (radio group label must be associated with either ARIA or a <fieldset> and <fieldset> is a badly designed HTML tag). The `sourceToCreate.readOnly` field tag must be grouped with the appropriate class `form-group` for proper display an positioning for subsequent fields.