### PR TITLE
Get the DiscoveryContextController test stubs working (as stubs) and fix incorrect parameter name in DiscoveryContextController.searchProcessKeyPress()

### DIFF
--- a/src/main/webapp/app/controllers/discoveryContextController.js
+++ b/src/main/webapp/app/controllers/discoveryContextController.js
@@ -136,7 +136,7 @@ sage.controller('DiscoveryContextController', function ($controller, $scope, $ro
       });
     };
 
-    $scope.searchProcessKeyPress = function($event) {
+    $scope.searchProcessKeyPress = function(event) {
       if (event.keyCode === 13 && $scope.currentSearchField) {
         $scope.discoveryContext.setSearchField($scope.currentSearchField.key, $scope.currentSearchValue);
         $scope.discoveryContext.executeSearch().then(function() {

--- a/src/main/webapp/tests/mocks/model/mockDiscoveryContext.js
+++ b/src/main/webapp/tests/mocks/model/mockDiscoveryContext.js
@@ -1,20 +1,126 @@
 var dataDiscoveryContext1 = {
-  id: 1
+  id: 1,
+  search: {
+    field: "all_fields",
+    value: "",
+    filters: [],
+    start: 0,
+    total: 0,
+    page: {
+      number: 0,
+      size: 10,
+      sort: "id",
+      offset: 0
+    }
+  }
 };
 
 var dataDiscoveryContext2 = {
-  id: 2
+  id: 2,
+  search: {
+    field: "",
+    value: "",
+    filters: [],
+    start: 0,
+    total: 0,
+    page: {
+      number: 0,
+      size: 10,
+      sort: "id",
+      offset: 0
+    }
+  }
 };
 
 var dataDiscoveryContext3 = {
-  id: 3
+  id: 3,
+  search: {
+    field: "",
+    value: "",
+    filters: [],
+    start: 0,
+    total: 0,
+    page: {
+      number: 0,
+      size: 10,
+      sort: "",
+      offset: 0
+    }
+  }
 };
 
 var mockDiscoveryContext = function($q) {
   var model = mockModel("DiscoveryContext", $q, dataDiscoveryContext1);
 
+  model.mockRouteParams = {};
+  model.mockSearching = false;
+
   model.ready = function() {
-    return $q.defer().promise;
+    var defer = $q.defer();
+    defer.resolve();
+    return defer.promise;
+  };
+
+  model.reload = function() {
+    var defer = $q.defer();
+    defer.resolve(model);
+    return defer.promise;
+  };
+
+  model.setSearchField = function(key, value) {
+    model.search.field = key;
+    model.search.value = value;
+  };
+
+  model.addFilter = function(label, key, value) {
+    var filter = {
+      label: label,
+      key: key,
+      value: value
+    };
+
+    if (!model.search.filters) {
+      model.search.filters = [];
+    }
+
+    model.search.filters.push(filter);
+    return model.executeSearch();
+  };
+
+  model.removeFilter = function(filter) {
+    for (var i = 0; i < model.search.filters.length; i++) {
+      var f = model.search.filters[i];
+      if (f.key === filter.key && f.value === filter.value) {
+        model.search.filters.splice(i, 1);
+      }
+    }
+    return model.executeSearch();
+  };
+
+  model.clearFilters = function() {
+    model.search.filters.length = 0;
+    return model.executeSearch();
+  };
+
+  model.executeSearch = function(maintainPage) {
+    return $q(function(resolve) {
+      resolve();
+    });
+  };
+
+  model.isSearching = function() {
+    return mockSearching;
+  };
+
+  model.buildPage = function() {
+    var page = {
+      number: 0,
+      size: 10,
+      sort: "id",
+      offset: 0
+    };
+
+    return page;
   };
 
   return model;

--- a/src/main/webapp/tests/mocks/services/mockAssumedControl.js
+++ b/src/main/webapp/tests/mocks/services/mockAssumedControl.js
@@ -1,0 +1,54 @@
+angular.module('mock.assumedControl', []).service('AssumedControl', function ($q) {
+  var service = mockService($q);
+
+  service.mockedCallbacks = [];
+  service.mockedPromise;
+
+  service.mockedData;
+
+  service.mockedAssumed = false;
+  service.mockedAssuming = false;
+
+  service.addCallback = function (callback) {
+    service.mockedCallbacks.push(callback);
+  };
+
+  service.assume = function(user) {
+    // @todo
+  };
+
+  service.cancel = function() {
+    service.set({
+      netid: "",
+      button: "Assume User",
+      status: ""
+    });
+  };
+
+  service.get = function(data) {
+    service.mockedPromise = $q.defer();
+
+    if (service.mockedData) {
+      service.mockedPromise.resolve();
+    } else {
+      service.mockedData = {};
+    }
+
+    return service.mockedData;
+  };
+
+  service.ready = function () {
+    return service.mockedPromise;
+  };
+
+  service.set = function(data) {
+    angular.extend(service.mockedData, data);
+    service.mockedPromise.resolve();
+  };
+
+  service.unassume = function(user) {
+    // @todo
+  };
+
+  return service;
+});

--- a/src/main/webapp/tests/unit/controllers/appLoginControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/appLoginControllerTest.js
@@ -9,8 +9,8 @@ describe("controller: AppLoginController", function () {
     });
   };
 
-  var initializeController = function(settings, _UserService_) {
-    inject(function ($controller, $rootScope) {
+  var initializeController = function(settings) {
+    inject(function ($controller, $rootScope, _UserService_) {
       scope = $rootScope.$new();
 
       sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";

--- a/src/main/webapp/tests/unit/controllers/discoveryContextControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/discoveryContextControllerTest.js
@@ -1,5 +1,5 @@
 describe("controller: DiscoveryContextController", function () {
-  var controller, location, q, scope, appConfig, routeParams, _DiscoveryContext_, MockedDiscoveryContext, WsApi;
+  var controller, location, q, scope, appConfig, routeParams, MockedDiscoveryContext, WsApi;
 
   var initializeVariables = function(settings) {
     inject(function ($location, $q, $routeParams, _WsApi_) {
@@ -18,7 +18,7 @@ describe("controller: DiscoveryContextController", function () {
     });
   };
 
-  var initializeController = function(settings, _DiscoveryContext_, _UserService_) {
+  var initializeController = function(settings) {
     inject(function ($controller, $rootScope) {
       scope = $rootScope.$new();
 
@@ -84,7 +84,7 @@ describe("controller: DiscoveryContextController", function () {
       expect(controller).toBeDefined();
     });
   });
-/*
+
   describe("Are the scope methods defined", function () {
     it("clearFilters should be defined", function () {
       expect(scope.clearFilters).toBeDefined();
@@ -165,8 +165,14 @@ describe("controller: DiscoveryContextController", function () {
 
     it("searchProcessKeyPress should work", function () {
       var result;
+      var event = {
+          which: 13,
+          target: {
+              blur: function() {}
+          }
+      };
 
-      result = scope.searchProcessKeyPress();
+      result = scope.searchProcessKeyPress(event);
       // @todo
     });
 
@@ -184,5 +190,4 @@ describe("controller: DiscoveryContextController", function () {
       // @todo
     });
   });
-  */
 });

--- a/src/main/webapp/tests/unit/controllers/singleResultControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/singleResultControllerTest.js
@@ -9,8 +9,8 @@ describe("controller: SingleResultController", function () {
     });
   };
 
-  var initializeController = function(settings, _UserService_) {
-    inject(function ($controller, $rootScope) {
+  var initializeController = function(settings) {
+    inject(function ($controller, $rootScope, _UserService_) {
       scope = $rootScope.$new();
 
       sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";


### PR DESCRIPTION
Getting the stubs to work will make it easier to write tests for issues in this sprint in regards to DiscoveryContextController.

The DiscoveryContextController function `searchProcessKeyPress()` had to be fixed due to an incorrect variable name usage (this is not a fix of the test but of operational code).

Consider this branch for basing from when doing work in `discoveryContextController.js` to ensure easier test writing and merging.

The `DiscoveryContext` model is unusual and is some sort of hybrid between a model, service, and/or repo.