### PR TITLE
[D-01289] Info Text in Discovery View does not save on Create

### DIFF
--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -13,7 +13,7 @@
           <div class="col-sm-10 col-sm-offset-1">
             <br>
             <validatedinput
-              id="createName"
+              id="discoveryViewToCreateName"
               model="discoveryViewToCreate"
               property="name"
               label="Name"
@@ -25,7 +25,7 @@
             </validatedinput>
 
             <validatedselect
-              id="createSource"
+              id="discoveryViewToCreateSource"
               model="discoveryViewToCreate"
               property="source"
               options="sources"
@@ -40,7 +40,7 @@
             </validatedselect>
 
             <validatedinput
-              id="createFilter"
+              id="discoveryViewToCreateFilter"
               model="discoveryViewToCreate"
               property="filter"
               label="Filter"
@@ -52,7 +52,7 @@
             </validatedinput>
 
             <validatedinput
-              id="createSlug"
+              id="discoveryViewToCreateSlug"
               model="discoveryViewToCreate"
               property="slug"
               label="Slug"
@@ -64,7 +64,7 @@
             </validatedinput>
 
             <validatedinput
-              id="createInfoLinkText"
+              id="discoveryViewToCreateInfoLinkText"
               model="discoveryViewToCreate"
               property="infoLinkText"
               label="Info Link Text"
@@ -76,7 +76,7 @@
             </validatedinput>
 
             <validatedinput
-              id="createInfoLinkUrl"
+              id="discoveryViewToCreateInfoLinkUrl"
               model="discoveryViewToCreate"
               property="infoLinkUrl"
               label="Info Link Url"
@@ -88,9 +88,9 @@
             </validatedinput>
 
             <validatedtextarea
-              property="idInfoText"
-              model="discoveryViewToCreate"
+              id="discoveryViewToCreateInfoText"
               property="infoText"
+              model="discoveryViewToCreate"
               label="Info Text"
               form="discoveryViewForms.create"
               validations="discoveryViewForms.validations"
@@ -223,7 +223,7 @@
           <div class="row">
             <div class="col-sm-5 col-sm-offset-1">
               <validatedselect
-                id="createUniqueIdentifierKey"
+                id="discoveryViewToCreateUniqueIdentifierKey"
                 model="discoveryViewToCreate"
                 property="uniqueIdentifierKey"
                 options="fields"
@@ -238,7 +238,7 @@
             </div>
             <div class="col-sm-5">
               <multi-suggestion-input
-                id="createTitleKey"
+                id="discoveryViewToCreateTitleKey"
                 model="discoveryViewToCreate"
                 property="titleKey"
                 optionproperty="name"
@@ -252,7 +252,7 @@
           <div class="row">
               <div class="col-sm-5 col-sm-offset-1">
                 <multi-suggestion-input
-                  id="createResourceThumbnailUriKey"
+                  id="discoveryViewToCreateThumbnailUriKey"
                   model="discoveryViewToCreate"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
@@ -264,7 +264,7 @@
               </div>
               <div class="col-sm-5">
                 <multi-suggestion-input
-                  id="createDiscoveryViewToCreate"
+                  id="discoveryViewToCreateResourceKey"
                   model="discoveryViewToCreate"
                   property="resourceLocationUriKey"
                   optionproperty="name"

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -13,7 +13,7 @@
           <div class="col-sm-10 col-sm-offset-1">
             <br>
             <validatedinput
-              id="updateName"
+              id="discoveryViewToUpdateName"
               model="discoveryViewToUpdate"
               property="name"
               label="Name"
@@ -25,7 +25,7 @@
             </validatedinput>
 
             <validatedselect
-              id="updateSource"
+              id="discoveryViewToUpdateSource"
               model="discoveryViewToUpdate"
               property="source"
               options="sources"
@@ -40,7 +40,7 @@
             </validatedselect>
 
             <validatedinput
-              id="updateFilter"
+              id="discoveryViewToUpdateFilter"
               model="discoveryViewToUpdate"
               property="filter"
               label="Filter"
@@ -52,7 +52,7 @@
             </validatedinput>
 
             <validatedinput
-              id="updateSlug"
+              id="discoveryViewToUpdateSlug"
               model="discoveryViewToUpdate"
               property="slug"
               label="Slug"
@@ -64,7 +64,7 @@
             </validatedinput>
 
             <validatedinput
-              id="updateInfoLinkText"
+              id="discoveryViewToUpdateInfoLinkText"
               model="discoveryViewToUpdate"
               property="infoLinkText"
               label="Info Link Text"
@@ -76,7 +76,7 @@
             </validatedinput>
 
             <validatedinput
-              id="updateInfoLinkUrl"
+              id="discoveryViewToUpdateInfoLinkUrl"
               model="discoveryViewToUpdate"
               property="infoLinkUrl"
               label="Info Link Url"
@@ -88,7 +88,7 @@
             </validatedinput>
 
             <validatedtextarea
-              id="updateInfoText"
+              id="discoveryViewToUpdateInfoText"
               model="discoveryViewToUpdate"
               property="infoText"
               label="Info Text"
@@ -223,7 +223,7 @@
           <div class="row">
             <div class="col-sm-5 col-sm-offset-1">
               <validatedselect
-                id="updateUniqueIdentifierKey"
+                id="discoveryViewToUpdateUniqueIdentifierKey"
                 model="discoveryViewToUpdate"
                 property="uniqueIdentifierKey"
                 options="fields"
@@ -238,7 +238,7 @@
             </div>
             <div class="col-sm-5">
               <multi-suggestion-input
-                id="updateTitleKey"
+                id="discoveryViewToUpdateTitleKey"
                 model="discoveryViewToUpdate"
                 property="titleKey"
                 optionproperty="name"
@@ -252,7 +252,7 @@
           <div class="row">
               <div class="col-sm-5 col-sm-offset-1">
                 <multi-suggestion-input
-                  id="updateResourceThumbnailUriKey"
+                  id="discoveryViewToUpdateResourceThumbnailUriKey"
                   model="discoveryViewToUpdate"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
@@ -264,7 +264,7 @@
               </div>
               <div class="col-sm-5">
                 <multi-suggestion-input
-                  id="updateResourceLocationUriKey"
+                  id="discoveryViewToUpdateResourceUriKey"
                   model="discoveryViewToUpdate"
                   property="resourceLocationUriKey"
                   optionproperty="name"

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -1,17 +1,21 @@
 describe("controller: DiscoveryViewManagementController", function () {
-  var controller, q, scope, NgTableParams, SearchField;
+  var controller, q, scope, DiscoveryViewRepo, NgTableParams, SearchField;
 
   var initializeVariables = function(settings) {
-    inject(function ($q, _WsApi_) {
+    inject(function ($q, _DiscoveryViewRepo_, _WsApi_) {
       q = $q;
 
+      DiscoveryViewRepo = _DiscoveryViewRepo_;
       NgTableParams = mockNgTableParams;
-      SearchField = mockSearchField;
+
+      SearchField = function() {
+        return new mockSearchField(q);
+      };
     });
   };
 
   var initializeController = function(settings) {
-    inject(function ($controller, $rootScope, _DiscoveryViewRepo_, _Source_, _SourceRepo_) {
+    inject(function ($controller, $rootScope, _Source_, _SourceRepo_) {
       scope = $rootScope.$new();
 
       sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -19,7 +23,7 @@ describe("controller: DiscoveryViewManagementController", function () {
 
       controller = $controller("DiscoveryViewManagementController", {
         $scope: scope,
-        DiscoveryViewRepo: _DiscoveryViewRepo_,
+        DiscoveryViewRepo: DiscoveryViewRepo,
         NgTableParams: NgTableParams,
         SearchField: SearchField,
         Source: _Source_,
@@ -184,8 +188,16 @@ describe("controller: DiscoveryViewManagementController", function () {
     it("createDiscoveryView should work", function () {
       var result;
 
+      scope.discoveryViewToCreate = DiscoveryViewRepo.getScaffold();
+
+      spyOn(DiscoveryViewRepo, "create").and.callThrough();
+      spyOn(scope, "cancelCreateDiscoveryView");
+
       result = scope.createDiscoveryView();
-      // @todo
+      scope.$digest();
+
+      expect(DiscoveryViewRepo.create).toHaveBeenCalled();
+      expect(scope.cancelCreateDiscoveryView).toHaveBeenCalled();
     });
     it("deleteDiscoveryView should work", function () {
       var result;


### PR DESCRIPTION
`property="idInfoText"` is Not valid and the valid `property="infoText"` is already defined.

Also, ids such as "createName" and "updateName" could be used on other modals very easily.
Use the full model name in the id to further guarantee distinctness.