### PR TITLE
[D-01284] Discovery View fields (metadatafields) do not always show when there is a valid value

### DIFF
--- a/src/main/java/edu/tamu/sage/model/DiscoveryView.java
+++ b/src/main/java/edu/tamu/sage/model/DiscoveryView.java
@@ -62,7 +62,7 @@ public class DiscoveryView extends ValidatingBaseEntity {
     private List<MetadataField> resultMetadataFields;
 
     @ElementCollection
-    private List<FacetFields> facetFields;
+    private List<FacetField> facetFields;
 
     @OrderColumn
     @ElementCollection
@@ -179,9 +179,9 @@ public class DiscoveryView extends ValidatingBaseEntity {
         return m;
     }
 
-    public FacetFields findFacetFieldByKey(String key) {
-        FacetFields f = null;
-        for (FacetFields ff : facetFields) {
+    public FacetField findFacetFieldByKey(String key) {
+        FacetField f = null;
+        for (FacetField ff : facetFields) {
             if (ff.getKey().equals(key)) {
                 f = ff;
                 break;
@@ -201,11 +201,11 @@ public class DiscoveryView extends ValidatingBaseEntity {
         return searchField;
     }
 
-    public List<FacetFields> getFacetFields() {
+    public List<FacetField> getFacetFields() {
         return facetFields;
     }
 
-    public void setFacetFields(List<FacetFields> facetFields) {
+    public void setFacetFields(List<FacetField> facetFields) {
         this.facetFields = facetFields;
     }
 

--- a/src/main/java/edu/tamu/sage/model/FacetField.java
+++ b/src/main/java/edu/tamu/sage/model/FacetField.java
@@ -3,7 +3,7 @@ package edu.tamu.sage.model;
 import javax.persistence.Embeddable;
 
 @Embeddable
-public class FacetFields {
+public class FacetField {
     
     private String key;
     
@@ -13,7 +13,7 @@ public class FacetFields {
     
     private String widget;
     
-    public FacetFields() {
+    public FacetField() {
         super();
     }
 

--- a/src/main/java/edu/tamu/sage/model/response/FacetFilter.java
+++ b/src/main/java/edu/tamu/sage/model/response/FacetFilter.java
@@ -3,9 +3,7 @@ package edu.tamu.sage.model.response;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.solr.client.solrj.response.FacetField;
-
-import edu.tamu.sage.model.FacetFields;
+import edu.tamu.sage.model.FacetField;
 
 public class FacetFilter {
 
@@ -60,7 +58,7 @@ public class FacetFilter {
         this.counts = counts;
     }
 
-    public static FacetFilter of(FacetField solrFacetField, FacetFields facetField) {
+    public static FacetFilter of(org.apache.solr.client.solrj.response.FacetField solrFacetField, FacetField facetField) {
         FacetFilter facetFilter = new FacetFilter();
         facetFilter.label = facetField.getLabel();
         facetFilter.key = facetField.getKey();
@@ -73,7 +71,7 @@ public class FacetFilter {
 
         return facetFilter;
     }
-    
-    
+
+
 
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -221,6 +221,8 @@
   <script src="model/fieldModel.js"></script>
   <script src="model/searchModel.js"></script>
   <script src="model/searchFieldModel.js"></script>
+  <script src="model/metadataFieldModel.js"></script>
+  <script src="model/facetFieldModel.js"></script>
 
   <!-- Components -->
   <script src="components/multiSuggestionInputComponent.js"></script>

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -323,6 +323,14 @@ var apiMapping = {
   SearchField: {
     validations: false,
     lazy: true
+  },
+  MetadataField: {
+    validations: false,
+    lazy: true
+  },
+  FacetField: {
+    validations: false,
+    lazy: true
   }
 
 };

--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -33,6 +33,11 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
       if ($scope.tabs.active < 0) {
         $scope.tabs.active = 0;
       } else {
+        if ($scope.tabs.active === 0 && angular.isDefined($scope.originalSourceName) && $scope.discoveryView.source.name !== $scope.originalSourceName) {
+          $scope.getFields($scope.discoveryView);
+          $scope.originalSourceName = $scope.discoveryView.source.name;
+        }
+
         $scope.tabs.active++;
       }
     } else {
@@ -83,6 +88,12 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
     dv.resultMetadataFields.push(metadataField);
   };
 
+  $scope.refreshSource = function(dv) {
+    if (dv.source.name !== $scope.originalSourceName && $scope.tabs.active !== 0) {
+      $scope.getFields(dv);
+    }
+  };
+
   $scope.startCreateDiscoveryView = function() {
     $scope.discoveryView = new DiscoveryView(DiscoveryViewRepo.getScaffold());
 
@@ -94,6 +105,8 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
 
     if (angular.isDefined($scope.sources) && $scope.sources.length > 0) {
       angular.extend($scope.discoveryView, { source: angular.copy($scope.sources[0]) });
+
+      $scope.originalSourceName = $scope.sources[0].name;
 
       $scope.getFields($scope.discoveryView);
     }
@@ -148,6 +161,7 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
 
   $scope.startUpdateDiscoveryView = function(dv) {
     $scope.discoveryView = new DiscoveryView(angular.copy(dv));
+    $scope.originalSourceName = $scope.discoveryView.source.name;
 
     if (dv.facetFields.length == 0) $scope.appendFacetFieldItem($scope.discoveryView);
     if (dv.searchFields.length == 0) $scope.appendSearchFieldItem($scope.discoveryView);

--- a/src/main/webapp/app/model/facetFieldModel.js
+++ b/src/main/webapp/app/model/facetFieldModel.js
@@ -1,0 +1,7 @@
+sage.model("FacetField", function () {
+  return function FacetField() {
+    var facetField = this;
+
+    return facetField;
+  };
+});

--- a/src/main/webapp/app/model/metadataFieldModel.js
+++ b/src/main/webapp/app/model/metadataFieldModel.js
@@ -1,0 +1,7 @@
+sage.model("MetadataField", function () {
+  return function MetadataField() {
+    var metadataField = this;
+
+    return metadataField;
+  };
+});

--- a/src/main/webapp/app/repo/discoveryViewRepo.js
+++ b/src/main/webapp/app/repo/discoveryViewRepo.js
@@ -9,10 +9,7 @@ sage.repo("DiscoveryViewRepo", function() {
     resourceLocationUriKey: "",
     resourceThumbnailUriKey: "",
     resultMetadataFields: [],
-    searchFields: [ {
-      key: "all_fields",
-      label: "Everything"
-    }],
+    searchFields: [],
     slug: "",
     titleKey: "",
     infoLinkText: "",
@@ -21,9 +18,26 @@ sage.repo("DiscoveryViewRepo", function() {
     uniqueIdentifierKey: ""
   };
 
+  discoveryViewRepo.scaffoldFacetField = {
+    key: "",
+    label: "",
+    type: "",
+    widget: ""
+  };
+
   discoveryViewRepo.scaffoldSearchField = {
     key: "",
     label: ""
+  };
+
+  discoveryViewRepo.scaffoldMetadataField = {
+    inGrid: true,
+    inList: true,
+    inSingleResult: true,
+    key: "",
+    label: "",
+    sortable: true,
+    type: ""
   };
 
   return discoveryViewRepo;

--- a/src/main/webapp/app/views/modals/confirmDeleteDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/confirmDeleteDiscoveryViewModal.html
@@ -5,18 +5,15 @@
   </div>
   <div class="modal-body">
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
-
-      <h3>Are you sure you want to remove:</h3>
-      <p>{{discoveryViewToDelete.name}}</p>
-
-
+    <h3>Are you sure you want to remove:</h3>
+    <p>{{discoveryView.name}}</p>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelDeleteDiscoveryView()">Cancel</button>
     <button type="submit" class="btn btn-danger">
-        <span ng-show="deletingDiscoveryView">
-          <span class="glyphicon glyphicon-refresh spinning"></span>
-        </span>
+      <span ng-show="deletingDiscoveryView">
+        <span class="glyphicon glyphicon-refresh spinning"></span>
+      </span>
       <span ng-hide="deletingDiscoveryView">Confirm</span>
     </button>
   </div>

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -7,7 +7,7 @@
     <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
-    <uib-tabset active="active.tab" justified="true">
+    <uib-tabset active="tabs.active" justified="true">
       <uib-tab index="0" heading="General">
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
@@ -107,35 +107,7 @@
               <h4>Facet Fields</h4>
             </div>
           </div>
-          <div class="row">
-            <div class="col-xs-2 col-sm-offset-1">
-              <div class="form-group">
-                <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
-              </div>
-            </div>
-            <div class="col-xs-5">
-              <div class="form-group">
-                <label for="name">Label</label>
-                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryView.facetFields[0].label">
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group">
-                <label for="key">Widget</label>
-                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].widget">
-                  <option>Link</option>
-                  <option>Typeahead</option>
-                </select>
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
-              </div>
-            </div>
-          </div>
-          <div class="row" ng-repeat="facetField in discoveryView.facetFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="facetField in discoveryView.facetFields track by $index">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -159,7 +131,8 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryView.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                <button ng-if="$index == 0" type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button ng-if="$index > 0" type="button" class="btn btn-danger" ng-click="discoveryView.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -172,26 +145,7 @@
               <h4>Search Fields</h4>
             </div>
           </div>
-          <div class="row">
-            <div class="col-xs-2 col-sm-offset-1">
-              <div class="form-group">
-                <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryView.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
-              </div>
-            </div>
-            <div class="col-xs-7">
-              <div class="form-group">
-                <label for="name">Label</label>
-                <input name="name" placeholder="Display name of search" type="text" class="form-control" ng-model="discoveryView.searchFields[0].label">
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
-              </div>
-            </div>
-          </div>
-          <div class="row" ng-repeat="searchField in discoveryView.searchFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="searchField in discoveryView.searchFields track by $index">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -206,7 +160,8 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryView.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                <button ng-if="$index == 0" type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button ng-if="$index > 0" type="button" class="btn btn-danger" ng-click="discoveryView.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -283,50 +238,7 @@
               <h4>Result Metadata</h4>
             </div>
           </div>
-          <div class="row">
-            <div class="col-xs-3 col-sm-offset-1" ng-init="discoveryView.resultMetadataFields[0]={searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true}">
-              <div class="form-group">
-                <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryView.resultMetadataFields[0].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryView.resultMetadataFields[0].sortable=!findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued"></select>
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group">
-                <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.resultMetadataFields[0].label">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="sortable">Sortable</label>
-                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].sortable" ng-disabled="findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="list">List</label>
-                <input name="list" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inList">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="grid">Grid</label>
-                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inGrid">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="item">Item</label>
-                <input name="item" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inSingleResult">
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="discoveryView.resultMetadataFields.push({searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true})"><span class="glyphicon glyphicon-plus"></span></button>
-              </div>
-            </div>
-          </div>
-          <div class="row" ng-repeat="resultMetadataField in discoveryView.resultMetadataFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="resultMetadataField in discoveryView.resultMetadataFields track by $index">
             <div class="col-xs-3 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -365,7 +277,8 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryView.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                <button ng-if="$index == 0" type="button" class="btn btn-success" ng-click="appendResultMetadataFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button ng-if="$index > 0" type="button" class="btn btn-danger" ng-click="discoveryView.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -375,12 +288,12 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelCreateDiscoveryView()">Cancel</button>
-    <button ng-show="active.tab === 0" ng-disabled="isDiscoveryViewGeneralInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
-    <button ng-show="active.tab === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="active.tab === 1" ng-disabled="isDiscoveryViewResultsInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
-    <button ng-show="active.tab === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="active.tab === 2" ng-disabled="isDiscoveryViewFacetsInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
-    <button ng-show="active.tab === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="active.tab === 3" ng-disabled="isDiscoveryViewSearchInvalid('create') || discoveryViewForms.create.$invalid" type="submit" class="btn btn-success">Create</button>
+    <button ng-show="tabs.active === 0" ng-disabled="isDiscoveryViewGeneralInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="tabs.active === 1" ng-disabled="isDiscoveryViewResultsInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="tabs.active === 2" ng-disabled="isDiscoveryViewFacetsInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="tabs.active === 3" ng-disabled="isDiscoveryViewSearchInvalid('create') || discoveryViewForms.create.$invalid" type="submit" class="btn btn-success">Create</button>
   </div>
 </form>

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -3,18 +3,18 @@
     <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelCreateDiscoveryView()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Create Discovery View</h4>
   </div>
-  <div class="modal-body">
+  <div class="modal-body" ng-if="discoveryView">
     <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
-    <uib-tabset active="activeJustified" justified="true">
+    <uib-tabset active="active.tab" justified="true">
       <uib-tab index="0" heading="General">
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
             <br>
             <validatedinput
               id="createName"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="name"
               label="Name"
               placeholder="Name for the new Discovery View"
@@ -26,7 +26,7 @@
 
             <validatedselect
               id="createSource"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="source"
               options="sources"
               optionproperty="name"
@@ -36,12 +36,12 @@
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
               autocomplete="off"
-              change="getFields(discoveryViewToCreate)">
+              change="getFields(discoveryView)">
             </validatedselect>
 
             <validatedinput
               id="createFilter"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="filter"
               label="Filter"
               placeholder=""
@@ -53,7 +53,7 @@
 
             <validatedinput
               id="createSlug"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="slug"
               label="Slug"
               placeholder="The URI slug of this Discovery View"
@@ -65,7 +65,7 @@
 
             <validatedinput
               id="createInfoLinkText"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="infoLinkText"
               label="Info Link Text"
               placeholder="e.g. 'About This Collection'"
@@ -77,7 +77,7 @@
 
             <validatedinput
               id="createInfoLinkUrl"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="infoLinkUrl"
               label="Info Link Url"
               placeholder="The URL of the info link"
@@ -89,7 +89,7 @@
 
             <validatedtextarea
               property="idInfoText"
-              model="discoveryViewToCreate"
+              model="discoveryView"
               property="infoText"
               label="Info Text"
               form="discoveryViewForms.create"
@@ -111,19 +111,19 @@
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.facetFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
               </div>
             </div>
             <div class="col-xs-5">
               <div class="form-group">
                 <label for="name">Label</label>
-                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryViewToCreate.facetFields[0].label">
+                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryView.facetFields[0].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="key">Widget</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.facetFields[0].widget">
+                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].widget">
                   <option>Link</option>
                   <option>Typeahead</option>
                 </select>
@@ -131,27 +131,27 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryViewToCreate)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="facetField in discoveryViewToCreate.facetFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="facetField in discoveryView.facetFields track by $index" ng-hide="$first">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.facetFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
+                <select name="key" class="form-control" ng-model="discoveryView.facetFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
               </div>
             </div>
             <div class="col-xs-5">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToCreate.facetFields[$index].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.facetFields[$index].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="widget">Widget</label>
-                <select name="widget" class="form-control" ng-model="discoveryViewToCreate.facetFields[$index].widget">
+                <select name="widget" class="form-control" ng-model="discoveryView.facetFields[$index].widget">
                   <option>Link</option>
                   <option>Typeahead</option>
                 </select>
@@ -159,7 +159,7 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToCreate.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                  <button type="button" class="btn btn-danger" ng-click="discoveryView.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -176,37 +176,37 @@
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
               </div>
             </div>
             <div class="col-xs-7">
               <div class="form-group">
                 <label for="name">Label</label>
-                <input name="name" placeholder="Display name of search" type="text" class="form-control" ng-model="discoveryViewToCreate.searchFields[0].label">
+                <input name="name" placeholder="Display name of search" type="text" class="form-control" ng-model="discoveryView.searchFields[0].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryViewToCreate)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="searchField in discoveryViewToCreate.searchFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="searchField in discoveryView.searchFields track by $index" ng-hide="$first">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.searchFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
+                <select name="key" class="form-control" ng-model="discoveryView.searchFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
               </div>
             </div>
             <div class="col-xs-7">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of search" type="text" class="form-control" ng-model="discoveryViewToCreate.searchFields[$index].label">
+                <input name="label" placeholder="Display label of search" type="text" class="form-control" ng-model="discoveryView.searchFields[$index].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToCreate.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                  <button type="button" class="btn btn-danger" ng-click="discoveryView.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -224,7 +224,7 @@
             <div class="col-sm-5 col-sm-offset-1">
               <validatedselect
                 id="createUniqueIdentifierKey"
-                model="discoveryViewToCreate"
+                model="discoveryView"
                 property="uniqueIdentifierKey"
                 options="fields"
                 optionproperty="name"
@@ -239,7 +239,7 @@
             <div class="col-sm-5">
               <multi-suggestion-input
                 id="createTitleKey"
-                model="discoveryViewToCreate"
+                model="discoveryView"
                 property="titleKey"
                 optionproperty="name"
                 suggestions="fields"
@@ -253,7 +253,7 @@
               <div class="col-sm-5 col-sm-offset-1">
                 <multi-suggestion-input
                   id="createResourceThumbnailUriKey"
-                  model="discoveryViewToCreate"
+                  model="discoveryView"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
                   suggestions="fields"
@@ -265,7 +265,7 @@
               <div class="col-sm-5">
                 <multi-suggestion-input
                   id="createDiscoveryViewToCreate"
-                  model="discoveryViewToCreate"
+                  model="discoveryView"
                   property="resourceLocationUriKey"
                   optionproperty="name"
                   suggestions="fields"
@@ -284,88 +284,88 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-xs-3 col-sm-offset-1" ng-init="discoveryViewToCreate.resultMetadataFields[0]={searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true}">
+            <div class="col-xs-3 col-sm-offset-1" ng-init="discoveryView.resultMetadataFields[0]={searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true}">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[0].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryViewToCreate.resultMetadataFields[0].sortable=!findFieldByKey(discoveryViewToCreate.resultMetadataFields[0].key).multivalued"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.resultMetadataFields[0].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryView.resultMetadataFields[0].sortable=!findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued"></select>
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[0].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.resultMetadataFields[0].label">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="sortable">Sortable</label>
-                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[0].sortable" ng-disabled="findFieldByKey(discoveryViewToCreate.resultMetadataFields[0].key).multivalued">
+                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].sortable" ng-disabled="findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="list">List</label>
-                <input name="list" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[0].inList">
+                <input name="list" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inList">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="grid">Grid</label>
-                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[0].inGrid">
+                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inGrid">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="item">Item</label>
-                <input name="item" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[0].inSingleResult">
+                <input name="item" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inSingleResult">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="discoveryViewToCreate.resultMetadataFields.push({searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true})"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="discoveryView.resultMetadataFields.push({searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true})"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="resultMetadataField in discoveryViewToCreate.resultMetadataFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="resultMetadataField in discoveryView.resultMetadataFields track by $index" ng-hide="$first">
             <div class="col-xs-3 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryViewToCreate.resultMetadataFields[$index].sortable=!findFieldByKey(discoveryViewToCreate.resultMetadataFields[$index].key).multivalued"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryView.resultMetadataFields[$index].sortable=!findFieldByKey(discoveryView.resultMetadataFields[$index].key).multivalued"></select>
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[$index].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].label">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="sortable">Sortable</label>
-                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[$index].sortable" ng-disabled="findFieldByKey(discoveryViewToCreate.resultMetadataFields[$index].key).multivalued">
+                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].sortable" ng-disabled="findFieldByKey(discoveryView.resultMetadataFields[$index].key).multivalued">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="list">List</label>
-                <input name="list" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[$index].inList">
+                <input name="list" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].inList">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="grid">Grid</label>
-                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[$index].inGrid">
+                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].inGrid">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="item">Item</label>
-                <input name="item" type="checkbox" class="form-control" ng-model="discoveryViewToCreate.resultMetadataFields[$index].inSingleResult">
+                <input name="item" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].inSingleResult">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToCreate.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                  <button type="button" class="btn btn-danger" ng-click="discoveryView.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -375,12 +375,12 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelCreateDiscoveryView()">Cancel</button>
-    <button ng-show="activeJustified == 0" ng-disabled="isDiscoveryViewGeneralInvalid('create')" type="button" class="btn btn-success" ng-click="activeJustified = 1; getFields(discoveryViewToCreate)">Next</button>
-    <button ng-show="activeJustified == 1" type="button" class="btn btn-success" ng-click="activeJustified = 0">Back</button>
-    <button ng-show="activeJustified == 1" ng-disabled="isDiscoveryViewResultsInvalid('create')" type="button" class="btn btn-success" ng-click="activeJustified = 2;">Next</button>
-    <button ng-show="activeJustified == 2" type="button" class="btn btn-success" ng-click="activeJustified = 1">Back</button>
-    <button ng-show="activeJustified == 2" ng-disabled="isDiscoveryViewFacetsInvalid('create')" type="button" class="btn btn-success" ng-click="activeJustified = 3;">Next</button>
-    <button ng-show="activeJustified == 3" type="button" class="btn btn-success" ng-click="activeJustified = 2">Back</button>
-    <button ng-show="activeJustified == 3" ng-disabled="isDiscoveryViewSearchInvalid('create') || discoveryViewForms.create.$invalid" type="submit" class="btn btn-success">Create</button>
+    <button ng-show="active.tab === 0" ng-disabled="isDiscoveryViewGeneralInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="active.tab === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="active.tab === 1" ng-disabled="isDiscoveryViewResultsInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="active.tab === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="active.tab === 2" ng-disabled="isDiscoveryViewFacetsInvalid('create')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="active.tab === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="active.tab === 3" ng-disabled="isDiscoveryViewSearchInvalid('create') || discoveryViewForms.create.$invalid" type="submit" class="btn btn-success">Create</button>
   </div>
 </form>

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -36,7 +36,7 @@
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
               autocomplete="off"
-              change="getFields(discoveryView)">
+              change="refreshSource(discoveryView)">
             </validatedselect>
 
             <validatedinput

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -36,7 +36,7 @@
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
               autocomplete="off"
-              change="getFields(discoveryView)">
+              change="refreshSource(discoveryView)">
             </validatedselect>
 
             <validatedinput

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -7,7 +7,7 @@
     <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
-    <uib-tabset active="active.tab" justified="true">
+    <uib-tabset active="tabs.active" justified="true">
       <uib-tab index="0" heading="General">
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
@@ -107,35 +107,7 @@
               <h4>Facet Fields</h4>
             </div>
           </div>
-          <div class="row">
-            <div class="col-xs-2 col-sm-offset-1">
-              <div class="form-group">
-                <label for="key">Key </label>
-                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
-              </div>
-            </div>
-            <div class="col-xs-5">
-              <div class="form-group">
-                <label for="name">Label</label>
-                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryView.facetFields[0].label">
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group">
-                <label for="key">Widget</label>
-                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].widget">
-                  <option>Link</option>
-                  <option>Typeahead</option>
-                </select>
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
-              </div>
-            </div>
-          </div>
-          <div class="row" ng-repeat="facetField in discoveryView.facetFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="facetField in discoveryView.facetFields track by $index">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -159,7 +131,8 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryView.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                <button ng-if="$index == 0" type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button ng-if="$index > 0" type="button" class="btn btn-danger" ng-click="discoveryView.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -172,26 +145,7 @@
               <h4>Search Fields</h4>
             </div>
           </div>
-          <div class="row">
-            <div class="col-xs-2 col-sm-offset-1">
-              <div class="form-group">
-                <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryView.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
-              </div>
-            </div>
-            <div class="col-xs-7">
-              <div class="form-group">
-                <label for="name">Label</label>
-                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryView.searchFields[0].label">
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
-              </div>
-            </div>
-          </div>
-          <div class="row" ng-repeat="searchField in discoveryView.searchFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="searchField in discoveryView.searchFields track by $index">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -201,12 +155,13 @@
             <div class="col-xs-7">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.searchFields[$index].label">
+                <input name="label" placeholder="Display label of field" type="text" class="form-control" ng-model="discoveryView.searchFields[$index].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryView.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                <button ng-if="$index == 0" type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button ng-if="$index > 0" type="button" class="btn btn-danger" ng-click="discoveryView.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -283,50 +238,7 @@
               <h4>Result Metadata</h4>
             </div>
           </div>
-          <div class="row">
-            <div class="col-xs-3 col-sm-offset-1" ng-init="discoveryView.resultMetadataFields[0]={searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true}">
-              <div class="form-group">
-                <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryView.resultMetadataFields[0].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryView.resultMetadataFields[0].sortable=!findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued"></select>
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group">
-                <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.resultMetadataFields[0].label">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="sortable">Sortable</label>
-                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].sortable" ng-disabled="findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="list">List</label>
-                <input name="list" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inList">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="grid">Grid</label>
-                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inGrid">
-              </div>
-            </div>
-            <div class="col-xs-1">
-              <div class="form-group">
-                <label for="item">Item</label>
-                <input name="item" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inSingleResult">
-              </div>
-            </div>
-            <div class="col-xs-2">
-              <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="discoveryView.resultMetadataFields.push({searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true})"><span class="glyphicon glyphicon-plus"></span></button>
-              </div>
-            </div>
-          </div>
-          <div class="row" ng-repeat="resultMetadataField in discoveryView.resultMetadataFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="resultMetadataField in discoveryView.resultMetadataFields track by $index">
             <div class="col-xs-3 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
@@ -365,7 +277,8 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryView.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                <button ng-if="$index == 0" type="button" class="btn btn-success" ng-click="appendResultMetadataFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button ng-if="$index > 0" type="button" class="btn btn-danger" ng-click="discoveryView.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -375,12 +288,12 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelUpdateDiscoveryView()">Cancel</button>
-    <button ng-show="active.tab === 0" ng-disabled="isDiscoveryViewGeneralInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
-    <button ng-show="active.tab === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="active.tab === 1" ng-disabled="isDiscoveryViewResultsInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
-    <button ng-show="active.tab === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="active.tab === 2" ng-disabled="isDiscoveryViewFiltersInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
-    <button ng-show="active.tab === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="active.tab === 3" ng-disabled="isDiscoveryViewSearchInvalid('update') || discoveryViewForms.update.$invalid" type="submit" class="btn btn-success">Update</button>
+    <button ng-show="tabs.active === 0" ng-disabled="isDiscoveryViewGeneralInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="tabs.active === 1" ng-disabled="isDiscoveryViewResultsInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="tabs.active === 2" ng-disabled="isDiscoveryViewFiltersInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="tabs.active === 3" ng-disabled="isDiscoveryViewSearchInvalid('update') || discoveryViewForms.update.$invalid" type="submit" class="btn btn-success">Update</button>
   </div>
 </form>

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -3,18 +3,18 @@
     <button type="button" class="close modal-close" aria-label="Close" ng-click="cancelUpdateDiscoveryView()"><span aria-hidden="true">&times;</span></button>
     <h4 class="modal-title">Edit Discovery View</h4>
   </div>
-  <div class="modal-body">
+  <div class="modal-body" ng-if="discoveryView">
     <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
-    <uib-tabset active="activeJustified" justified="true">
+    <uib-tabset active="active.tab" justified="true">
       <uib-tab index="0" heading="General">
         <div class="row">
           <div class="col-sm-10 col-sm-offset-1">
             <br>
             <validatedinput
               id="updateName"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="name"
               label="Name"
               placeholder="Name for the updated Discovery View"
@@ -26,7 +26,7 @@
 
             <validatedselect
               id="updateSource"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="source"
               options="sources"
               optionproperty="name"
@@ -36,12 +36,12 @@
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
               autocomplete="off"
-              change="getFields(discoveryViewToUpdate)">
+              change="getFields(discoveryView)">
             </validatedselect>
 
             <validatedinput
               id="updateFilter"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="filter"
               label="Filter"
               placeholder=""
@@ -53,7 +53,7 @@
 
             <validatedinput
               id="updateSlug"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="slug"
               label="Slug"
               placeholder="The URI slug of this Discovery View"
@@ -65,7 +65,7 @@
 
             <validatedinput
               id="updateInfoLinkText"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="infoLinkText"
               label="Info Link Text"
               placeholder="e.g. 'About This Collection'"
@@ -77,7 +77,7 @@
 
             <validatedinput
               id="updateInfoLinkUrl"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="infoLinkUrl"
               label="Info Link Url"
               placeholder="The URL of the info link"
@@ -89,7 +89,7 @@
 
             <validatedtextarea
               id="updateInfoText"
-              model="discoveryViewToUpdate"
+              model="discoveryView"
               property="infoText"
               label="Info Text"
               form="discoveryViewForms.update"
@@ -110,20 +110,20 @@
           <div class="row">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
-                <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.facetFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
+                <label for="key">Key </label>
+                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
               </div>
             </div>
             <div class="col-xs-5">
               <div class="form-group">
                 <label for="name">Label</label>
-                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.facetFields[0].label">
+                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryView.facetFields[0].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="key">Widget</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.facetFields[0].widget">
+                <select name="key" class="form-control" ng-model="discoveryView.facetFields[0].widget">
                   <option>Link</option>
                   <option>Typeahead</option>
                 </select>
@@ -131,27 +131,27 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryViewToUpdate)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendFacetFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="facetField in discoveryViewToUpdate.facetFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="facetField in discoveryView.facetFields track by $index" ng-hide="$first">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.facetFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
+                <select name="key" class="form-control" ng-model="discoveryView.facetFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
               </div>
             </div>
             <div class="col-xs-5">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.facetFields[$index].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.facetFields[$index].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="widget">Widget</label>
-                <select name="widget" class="form-control" ng-model="discoveryViewToUpdate.facetFields[$index].widget">
+                <select name="widget" class="form-control" ng-model="discoveryView.facetFields[$index].widget">
                   <option>Link</option>
                   <option>Typeahead</option>
                 </select>
@@ -159,7 +159,7 @@
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToUpdate.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                  <button type="button" class="btn btn-danger" ng-click="discoveryView.facetFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -176,37 +176,37 @@
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.searchFields[0].key" ng-options="option['name'] as option['name'] for option in fields"></select>
               </div>
             </div>
             <div class="col-xs-7">
               <div class="form-group">
                 <label for="name">Label</label>
-                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.searchFields[0].label">
+                <input name="name" placeholder="Display name of filter" type="text" class="form-control" ng-model="discoveryView.searchFields[0].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryViewToUpdate)"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="appendSearchFieldItem(discoveryView)"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="searchField in discoveryViewToUpdate.searchFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="searchField in discoveryView.searchFields track by $index" ng-hide="$first">
             <div class="col-xs-2 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.searchFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
+                <select name="key" class="form-control" ng-model="discoveryView.searchFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ></select>
               </div>
             </div>
             <div class="col-xs-7">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.searchFields[$index].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.searchFields[$index].label">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToUpdate.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                  <button type="button" class="btn btn-danger" ng-click="discoveryView.searchFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -224,7 +224,7 @@
             <div class="col-sm-5 col-sm-offset-1">
               <validatedselect
                 id="updateUniqueIdentifierKey"
-                model="discoveryViewToUpdate"
+                model="discoveryView"
                 property="uniqueIdentifierKey"
                 options="fields"
                 optionproperty="name"
@@ -239,7 +239,7 @@
             <div class="col-sm-5">
               <multi-suggestion-input
                 id="updateTitleKey"
-                model="discoveryViewToUpdate"
+                model="discoveryView"
                 property="titleKey"
                 optionproperty="name"
                 suggestions="fields"
@@ -253,7 +253,7 @@
               <div class="col-sm-5 col-sm-offset-1">
                 <multi-suggestion-input
                   id="updateResourceThumbnailUriKey"
-                  model="discoveryViewToUpdate"
+                  model="discoveryView"
                   property="resourceThumbnailUriKey"
                   optionproperty="name"
                   suggestions="fields"
@@ -265,7 +265,7 @@
               <div class="col-sm-5">
                 <multi-suggestion-input
                   id="updateResourceLocationUriKey"
-                  model="discoveryViewToUpdate"
+                  model="discoveryView"
                   property="resourceLocationUriKey"
                   optionproperty="name"
                   suggestions="fields"
@@ -284,88 +284,88 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-xs-3 col-sm-offset-1" ng-init="discoveryViewToUpdate.resultMetadataFields[0]={searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true}">
+            <div class="col-xs-3 col-sm-offset-1" ng-init="discoveryView.resultMetadataFields[0]={searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true}">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[0].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryViewToUpdate.resultMetadataFields[0].sortable=!findFieldByKey(discoveryViewToUpdate.resultMetadataFields[0].key).multivalued"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.resultMetadataFields[0].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryView.resultMetadataFields[0].sortable=!findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued"></select>
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[0].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.resultMetadataFields[0].label">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="sortable">Sortable</label>
-                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[0].sortable" ng-disabled="findFieldByKey(discoveryViewToUpdate.resultMetadataFields[0].key).multivalued">
+                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].sortable" ng-disabled="findFieldByKey(discoveryView.resultMetadataFields[0].key).multivalued">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="list">List</label>
-                <input name="list" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[0].inList">
+                <input name="list" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inList">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="grid">Grid</label>
-                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[0].inGrid">
+                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inGrid">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="item">Item</label>
-                <input name="item" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[0].inSingleResult">
+                <input name="item" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[0].inSingleResult">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                <button type="button" class="btn btn-success" ng-click="discoveryViewToUpdate.resultMetadataFields.push({searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true})"><span class="glyphicon glyphicon-plus"></span></button>
+                <button type="button" class="btn btn-success" ng-click="discoveryView.resultMetadataFields.push({searchable:true,sortable:true,inList:true,inGrid:true,inSingleResult:true})"><span class="glyphicon glyphicon-plus"></span></button>
               </div>
             </div>
           </div>
-          <div class="row" ng-repeat="resultMetadataField in discoveryViewToUpdate.resultMetadataFields track by $index" ng-hide="$first">
+          <div class="row" ng-repeat="resultMetadataField in discoveryView.resultMetadataFields track by $index" ng-hide="$first">
             <div class="col-xs-3 col-sm-offset-1">
               <div class="form-group">
                 <label for="key">Key</label>
-                <select name="key" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryViewToUpdate.resultMetadataFields[$index].sortable=!findFieldByKey(discoveryViewToUpdate.resultMetadataFields[$index].key).multivalued"></select>
+                <select name="key" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].key" ng-options="option['name'] as option['name'] for option in fields" ng-change="discoveryView.resultMetadataFields[$index].sortable=!findFieldByKey(discoveryView.resultMetadataFields[$index].key).multivalued"></select>
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group">
                 <label for="label">Label</label>
-                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[$index].label">
+                <input name="label" placeholder="Display label of filter" type="text" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].label">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="sortable">Sortable</label>
-                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[$index].sortable" ng-disabled="findFieldByKey(discoveryViewToUpdate.resultMetadataFields[$index].key).multivalued">
+                <input name="sortable" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].sortable" ng-disabled="findFieldByKey(discoveryView.resultMetadataFields[$index].key).multivalued">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="list">List</label>
-                <input name="list" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[$index].inList">
+                <input name="list" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].inList">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="grid">Grid</label>
-                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[$index].inGrid">
+                <input name="grid" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].inGrid">
               </div>
             </div>
             <div class="col-xs-1">
               <div class="form-group">
                 <label for="item">Item</label>
-                <input name="item" type="checkbox" class="form-control" ng-model="discoveryViewToUpdate.resultMetadataFields[$index].inSingleResult">
+                <input name="item" type="checkbox" class="form-control" ng-model="discoveryView.resultMetadataFields[$index].inSingleResult">
               </div>
             </div>
             <div class="col-xs-2">
               <div class="form-group add-field-group">
-                  <button type="button" class="btn btn-danger" ng-click="discoveryViewToUpdate.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
+                  <button type="button" class="btn btn-danger" ng-click="discoveryView.resultMetadataFields.splice($index,1)"><span class="glyphicon glyphicon-minus"></span></button>
               </div>
             </div>
           </div>
@@ -375,12 +375,12 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelUpdateDiscoveryView()">Cancel</button>
-    <button ng-show="activeJustified == 0" ng-disabled="isDiscoveryViewGeneralInvalid('update')" type="button" class="btn btn-success" ng-click="activeJustified = 1; getFields(discoveryViewToUpdate)">Next</button>
-    <button ng-show="activeJustified == 1" type="button" class="btn btn-success" ng-click="activeJustified = 0">Back</button>
-    <button ng-show="activeJustified == 1" ng-disabled="isDiscoveryViewResultsInvalid('update')" type="button" class="btn btn-success" ng-click="activeJustified = 2">Next</button>
-    <button ng-show="activeJustified == 2" type="button" class="btn btn-success" ng-click="activeJustified = 1">Back</button>
-    <button ng-show="activeJustified == 2" ng-disabled="isDiscoveryViewFiltersInvalid('update')" type="button" class="btn btn-success" ng-click="activeJustified = 3">Next</button>
-    <button ng-show="activeJustified == 3" type="button" class="btn btn-success" ng-click="activeJustified = 2">Back</button>
-    <button ng-show="activeJustified == 3" ng-disabled="isDiscoveryViewSearchInvalid('update') || discoveryViewForms.update.$invalid" type="submit" class="btn btn-success">Update</button>
+    <button ng-show="active.tab === 0" ng-disabled="isDiscoveryViewGeneralInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="active.tab === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="active.tab === 1" ng-disabled="isDiscoveryViewResultsInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="active.tab === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="active.tab === 2" ng-disabled="isDiscoveryViewFiltersInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="active.tab === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>
+    <button ng-show="active.tab === 3" ng-disabled="isDiscoveryViewSearchInvalid('update') || discoveryViewForms.update.$invalid" type="submit" class="btn btn-success">Update</button>
   </div>
 </form>

--- a/src/main/webapp/tests/mocks/model/mockFacetField.js
+++ b/src/main/webapp/tests/mocks/model/mockFacetField.js
@@ -1,0 +1,31 @@
+var dataFacetField1 = {
+  id: 1,
+  key: "facet_field_1",
+  label: "Facet Field 1",
+  type: "",
+  widget: ""
+};
+
+var dataFacetField2 = {
+  id: 2,
+  key: "facet_field_2",
+  label: "Facet Field 2",
+  type: "",
+  widget: ""
+};
+
+var dataFacetField3 = {
+  id: 3,
+  key: "facet_field_3",
+  label: "Facet Field 3",
+  type: "",
+  widget: ""
+};
+
+var mockFacetField = function($q) {
+  var model = mockModel("FacetField", $q, dataFacetField1);
+
+  return model;
+};
+
+angular.module("mock.facetField", []).service("FacetField", mockFacetField);

--- a/src/main/webapp/tests/mocks/model/mockMetadataField.js
+++ b/src/main/webapp/tests/mocks/model/mockMetadataField.js
@@ -1,0 +1,40 @@
+var dataMetadataField1 = {
+  id: 1,
+  inGrid: true,
+  inList: true,
+  inSingleResult: true,
+  key: "metadata_field_1",
+  label: "Metadata Field 1",
+  sortable: true,
+  type: ""
+};
+
+var dataMetadataField2 = {
+  id: 2,
+  inGrid: false,
+  inList: false,
+  inSingleResult: false,
+  key: "metadata_field_2",
+  label: "Metadata Field 2",
+  sortable: false,
+  type: ""
+};
+
+var dataMetadataField3 = {
+  id: 3,
+  inGrid: false,
+  inList: false,
+  inSingleResult: true,
+  key: "metadata_field_3",
+  label: "Metadata Field 3",
+  sortable: true,
+  type: ""
+};
+
+var mockMetadataField = function($q) {
+  var model = mockModel("MetadataField", $q, dataMetadataField1);
+
+  return model;
+};
+
+angular.module("mock.metadataField", []).service("MetadataField", mockMetadataField);

--- a/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
+++ b/src/main/webapp/tests/mocks/repo/mockDiscoveryViewRepo.js
@@ -27,10 +27,7 @@ angular.module("mock.discoveryViewRepo", []).service("DiscoveryViewRepo", functi
     resourceLocationUriKey: "",
     resourceThumbnailUriKey: "",
     resultMetadataFields: [],
-    searchFields: [ {
-        key: "all_fields",
-        label: "Everything"
-    }],
+    searchFields: [],
     slug: "",
     titleKey: "",
     infoLinkText: "",
@@ -42,6 +39,16 @@ angular.module("mock.discoveryViewRepo", []).service("DiscoveryViewRepo", functi
   repo.scaffoldSearchField = {
     key: "",
     label: ""
+  };
+
+  repo.scaffoldMetadataField = {
+    inGrid: true,
+    inList: true,
+    inSingleResult: true,
+    key: "",
+    label: "",
+    sortable: true,
+    type: ""
   };
 
   return repo;

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -1,17 +1,33 @@
 describe("controller: DiscoveryViewManagementController", function () {
-  var controller, q, scope, NgTableParams, SearchField;
+  var controller, q, scope, DiscoveryView, DiscoveryViewRepo, FacetField, MetadataField, NgTableParams, SearchField;
 
   var initializeVariables = function(settings) {
-    inject(function ($q, _WsApi_) {
+    inject(function ($q, _DiscoveryViewRepo_, _WsApi_) {
       q = $q;
 
+      DiscoveryViewRepo = _DiscoveryViewRepo_;
       NgTableParams = mockNgTableParams;
-      SearchField = mockSearchField;
+
+      DiscoveryView = function() {
+        return new mockDiscoveryView(q);
+      };
+
+      FacetField = function() {
+        return new mockFacetField(q);
+      };
+
+      MetadataField = function() {
+        return new mockMetadataField(q);
+      };
+
+      SearchField = function() {
+        return new mockSearchField(q);
+      };
     });
   };
 
   var initializeController = function(settings) {
-    inject(function ($controller, $rootScope, _DiscoveryViewRepo_, _Source_, _SourceRepo_) {
+    inject(function ($controller, $rootScope, _Source_, _SourceRepo_) {
       scope = $rootScope.$new();
 
       sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -19,7 +35,10 @@ describe("controller: DiscoveryViewManagementController", function () {
 
       controller = $controller("DiscoveryViewManagementController", {
         $scope: scope,
-        DiscoveryViewRepo: _DiscoveryViewRepo_,
+        DiscoveryView: DiscoveryView,
+        DiscoveryViewRepo: DiscoveryViewRepo,
+        FacetField: FacetField,
+        MetadataField: MetadataField,
         NgTableParams: NgTableParams,
         SearchField: SearchField,
         Source: _Source_,
@@ -38,6 +57,8 @@ describe("controller: DiscoveryViewManagementController", function () {
     module("sage");
     module("mock.discoveryView");
     module("mock.discoveryViewRepo");
+    module("mock.facetField");
+    module("mock.metadataField");
     module("mock.ngTableParams");
     module("mock.searchField");
     module("mock.source");
@@ -53,14 +74,17 @@ describe("controller: DiscoveryViewManagementController", function () {
     it("should be defined for admin", function () {
       expect(controller).toBeDefined();
     });
+
     it("should be defined for manager", function () {
       initializeController({role: "ROLE_MANAGER"});
       expect(controller).toBeDefined();
     });
+
     it("should be defined for user", function () {
       initializeController({role: "ROLE_USER"});
       expect(controller).toBeDefined();
     });
+
     it("should be defined for anonymous", function () {
       initializeController({role: "ROLE_ANONYMOUS"});
       expect(controller).toBeDefined();
@@ -72,70 +96,102 @@ describe("controller: DiscoveryViewManagementController", function () {
       expect(scope.appendFacetFieldItem).toBeDefined();
       expect(typeof scope.appendFacetFieldItem).toEqual("function");
     });
+
+    it("appendResultMetadataFieldItem should be defined", function () {
+      expect(scope.appendResultMetadataFieldItem).toBeDefined();
+      expect(typeof scope.appendResultMetadataFieldItem).toEqual("function");
+    });
+
     it("appendSearchFieldItem should be defined", function () {
       expect(scope.appendSearchFieldItem).toBeDefined();
       expect(typeof scope.appendSearchFieldItem).toEqual("function");
     });
+
+    it("back should be defined", function () {
+      expect(scope.back).toBeDefined();
+      expect(typeof scope.back).toEqual("function");
+    });
+
     it("cancelCreateDiscoveryView should be defined", function () {
       expect(scope.cancelCreateDiscoveryView).toBeDefined();
       expect(typeof scope.cancelCreateDiscoveryView).toEqual("function");
     });
+
     it("cancelDeleteDiscoveryView should be defined", function () {
       expect(scope.cancelDeleteDiscoveryView).toBeDefined();
       expect(typeof scope.cancelDeleteDiscoveryView).toEqual("function");
     });
+
     it("cancelUpdateDiscoveryView should be defined", function () {
       expect(scope.cancelUpdateDiscoveryView).toBeDefined();
       expect(typeof scope.cancelUpdateDiscoveryView).toEqual("function");
     });
+
     it("confirmDeleteDiscoveryView should be defined", function () {
       expect(scope.confirmDeleteDiscoveryView).toBeDefined();
       expect(typeof scope.confirmDeleteDiscoveryView).toEqual("function");
     });
+
     it("createDiscoveryView should be defined", function () {
       expect(scope.createDiscoveryView).toBeDefined();
       expect(typeof scope.createDiscoveryView).toEqual("function");
     });
+
     it("deleteDiscoveryView should be defined", function () {
       expect(scope.deleteDiscoveryView).toBeDefined();
       expect(typeof scope.deleteDiscoveryView).toEqual("function");
     });
+
     it("findFieldByKey should be defined", function () {
       expect(scope.findFieldByKey).toBeDefined();
       expect(typeof scope.findFieldByKey).toEqual("function");
     });
+
     it("getFields should be defined", function () {
       expect(scope.getFields).toBeDefined();
       expect(typeof scope.getFields).toEqual("function");
     });
+
     it("isDiscoveryViewFacetsInvalid should be defined", function () {
       expect(scope.isDiscoveryViewFacetsInvalid).toBeDefined();
       expect(typeof scope.isDiscoveryViewFacetsInvalid).toEqual("function");
     });
+
     it("isDiscoveryViewGeneralInvalid should be defined", function () {
       expect(scope.isDiscoveryViewGeneralInvalid).toBeDefined();
       expect(typeof scope.isDiscoveryViewGeneralInvalid).toEqual("function");
     });
+
     it("isDiscoveryViewResultsInvalid should be defined", function () {
       expect(scope.isDiscoveryViewResultsInvalid).toBeDefined();
       expect(typeof scope.isDiscoveryViewResultsInvalid).toEqual("function");
     });
+
     it("isDiscoveryViewSearchInvalid should be defined", function () {
       expect(scope.isDiscoveryViewSearchInvalid).toBeDefined();
       expect(typeof scope.isDiscoveryViewSearchInvalid).toEqual("function");
     });
+
+    it("next should be defined", function () {
+      expect(scope.next).toBeDefined();
+      expect(typeof scope.next).toEqual("function");
+    });
+
     it("resetDiscoveryViewForms should be defined", function () {
       expect(scope.resetDiscoveryViewForms).toBeDefined();
       expect(typeof scope.resetDiscoveryViewForms).toEqual("function");
     });
+
     it("startCreateDiscoveryView should be defined", function () {
       expect(scope.startCreateDiscoveryView).toBeDefined();
       expect(typeof scope.startCreateDiscoveryView).toEqual("function");
     });
+
     it("startUpdateDiscoveryView should be defined", function () {
       expect(scope.startUpdateDiscoveryView).toBeDefined();
       expect(typeof scope.startUpdateDiscoveryView).toEqual("function");
     });
+
     it("updateDiscoveryView should be defined", function () {
       expect(scope.updateDiscoveryView).toBeDefined();
       expect(typeof scope.updateDiscoveryView).toEqual("function");
@@ -144,73 +200,116 @@ describe("controller: DiscoveryViewManagementController", function () {
 
   describe("Do the scope methods work as expected", function () {
     it("appendFacetFieldItem should work", function () {
-      var result;
       var dv = new mockDiscoveryView(q);
+      var length = dv.facetFields.length;
 
-      result = scope.appendFacetFieldItem(dv);
-      // @todo
+      scope.appendFacetFieldItem(dv);
+      expect(dv.facetFields.length).toBe(length + 1);
     });
-    it("appendSearchFieldItem should work", function () {
-      var result;
+
+    it("appendResultMetadataFieldItem should work", function () {
       var dv = new mockDiscoveryView(q);
+      var length = dv.resultMetadataFields.length;
+
+      scope.appendResultMetadataFieldItem(dv);
+      expect(dv.resultMetadataFields.length).toBe(length + 1);
+    });
+
+    it("appendSearchFieldItem should work", function () {
+      var dv = new mockDiscoveryView(q);
+      var length = dv.searchFields.length;
 
       result = scope.appendSearchFieldItem(dv);
-      // @todo
+      expect(dv.searchFields.length).toBe(length + 1);
     });
+
+    it("back should work", function () {
+      scope.tabs.active = scope.tabs.length + 1;
+      scope.back();
+      expect(scope.tabs.active).toBe(scope.tabs.length - 1);
+
+      scope.tabs.active = 1;
+      scope.back();
+      expect(scope.tabs.active).toBe(0);
+
+      scope.back();
+      expect(scope.tabs.active).toBe(0);
+
+      scope.tabs.active = -1;
+      scope.back();
+      expect(scope.tabs.active).toBe(0);
+    });
+
     it("cancelCreateDiscoveryView should work", function () {
       var result;
 
       result = scope.cancelCreateDiscoveryView();
       // @todo
     });
+
     it("cancelDeleteDiscoveryView should work", function () {
       var result;
 
       result = scope.cancelDeleteDiscoveryView();
       // @todo
     });
+
     it("cancelUpdateDiscoveryView should work", function () {
       var result;
 
       result = scope.cancelUpdateDiscoveryView();
       // @todo
     });
+
+    it("createDiscoveryView should work", function () {
+      var result;
+      var discoveryView = new mockDiscoveryView(q);
+
+      scope.discoveryView = discoveryView;
+
+      result = scope.createDiscoveryView();
+      scope.$digest();
+      // @todo
+    });
+
+    it("deleteDiscoveryView should work", function () {
+      var result;
+      var discoveryView = new mockDiscoveryView(q);
+
+      scope.discoveryView = discoveryView;
+
+      result = scope.deleteDiscoveryView();
+      // @todo
+    });
+
     it("confirmDeleteDiscoveryView should work", function () {
       var result;
 
       result = scope.confirmDeleteDiscoveryView();
       // @todo
     });
-    it("createDiscoveryView should work", function () {
-      var result;
 
-      result = scope.createDiscoveryView();
-      // @todo
-    });
-    it("deleteDiscoveryView should work", function () {
-      var result;
-
-      result = scope.deleteDiscoveryView();
-      // @todo
-    });
     it("findFieldByKey should work", function () {
       var result;
 
       result = scope.findFieldByKey();
       // @todo
     });
+
     it("getFields should work", function () {
       var result;
 
       result = scope.getFields();
       // @todo
     });
+
     it("isDiscoveryViewFacetsInvalid should work", function () {
       var result;
 
       result = scope.isDiscoveryViewFacetsInvalid("create");
       // @todo
     });
+
     it("isDiscoveryViewGeneralInvalid should work", function () {
       var result;
       scope.discoveryViewForms = {};
@@ -219,6 +318,7 @@ describe("controller: DiscoveryViewManagementController", function () {
       result = scope.isDiscoveryViewGeneralInvalid("create");
       // @todo
     });
+
     it("isDiscoveryViewResultsInvalid should work", function () {
       var result;
       scope.discoveryViewForms = {};
@@ -227,24 +327,45 @@ describe("controller: DiscoveryViewManagementController", function () {
       result = scope.isDiscoveryViewResultsInvalid("create");
       // @todo
     });
+
     it("isDiscoveryViewSearchInvalid should work", function () {
       var result;
 
       result = scope.isDiscoveryViewSearchInvalid("create");
       // @todo
     });
+
+    it("next should work", function () {
+      scope.tabs.active = -2;
+      scope.next();
+      expect(scope.tabs.active).toBe(0);
+
+      scope.next();
+      expect(scope.tabs.active).toBe(1);
+
+      scope.tabs.active = scope.tabs.length - 2;
+      scope.next();
+      expect(scope.tabs.active).toBe(scope.tabs.length - 1);
+
+      scope.tabs.active = scope.tabs.length;
+      scope.next();
+      expect(scope.tabs.active).toBe(scope.tabs.length - 1);
+    });
+
     it("resetDiscoveryViewForms should work", function () {
       var result;
 
       result = scope.resetDiscoveryViewForms();
       // @todo
     });
+
     it("startCreateDiscoveryView should work", function () {
       var result;
 
       result = scope.startCreateDiscoveryView();
       // @todo
     });
+
     it("startUpdateDiscoveryView should work", function () {
       var result;
       var dv = new mockDiscoveryView(q);
@@ -252,9 +373,12 @@ describe("controller: DiscoveryViewManagementController", function () {
       result = scope.startUpdateDiscoveryView(dv);
       // @todo
     });
+
     it("updateDiscoveryView should work", function () {
       var result;
-      scope.discoveryViewToUpdate = new mockDiscoveryView(q);
+      var discoveryView = new mockDiscoveryView(q);
+
+      scope.discoveryView = discoveryView;
 
       result = scope.updateDiscoveryView();
       // @todo

--- a/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/discoveryViewManagementControllerTest.js
@@ -177,6 +177,11 @@ describe("controller: DiscoveryViewManagementController", function () {
       expect(typeof scope.next).toEqual("function");
     });
 
+    it("refreshSource should be defined", function () {
+      expect(scope.refreshSource).toBeDefined();
+      expect(typeof scope.refreshSource).toEqual("function");
+    });
+
     it("resetDiscoveryViewForms should be defined", function () {
       expect(scope.resetDiscoveryViewForms).toBeDefined();
       expect(typeof scope.resetDiscoveryViewForms).toEqual("function");
@@ -350,6 +355,24 @@ describe("controller: DiscoveryViewManagementController", function () {
       scope.tabs.active = scope.tabs.length;
       scope.next();
       expect(scope.tabs.active).toBe(scope.tabs.length - 1);
+    });
+
+    it("refreshSource should work", function () {
+      var dv = new mockDiscoveryView(q);
+
+      spyOn(scope, 'getFields');
+
+      scope.tabs.active = 0;
+      scope.refreshSource(dv);
+      expect(scope.getFields).not.toHaveBeenCalled();
+
+      scope.tabs.active = 1;
+      scope.refreshSource(dv);
+      expect(scope.getFields).not.toHaveBeenCalled();
+
+      scope.originalSourceName = "differentName";
+      scope.refreshSource(dv);
+      expect(scope.getFields).toHaveBeenCalled();
     });
 
     it("resetDiscoveryViewForms should work", function () {

--- a/src/main/webapp/tests/unit/models/facetFieldModelTest.js
+++ b/src/main/webapp/tests/unit/models/facetFieldModelTest.js
@@ -1,0 +1,34 @@
+describe('model: MetadataField', function () {
+  var model, rootScope, scope, WsApi;
+
+  var initializeVariables = function(settings) {
+    inject(function ($rootScope, _WsApi_) {
+      rootScope = $rootScope;
+
+      WsApi = _WsApi_;
+    });
+  };
+
+  var initializeModel = function(settings) {
+    inject(function (MetadataField) {
+      scope = rootScope.$new();
+
+      model = angular.extend(new MetadataField());
+    });
+  };
+
+  beforeEach(function() {
+    module('core');
+    module('sage');
+    module('mock.wsApi');
+
+    initializeVariables();
+    initializeModel();
+  });
+
+  describe('Is the model defined', function () {
+    it('should be defined', function () {
+      expect(model).toBeDefined();
+    });
+  });
+});

--- a/src/main/webapp/tests/unit/models/metadataFieldModelTest.js
+++ b/src/main/webapp/tests/unit/models/metadataFieldModelTest.js
@@ -1,0 +1,34 @@
+describe('model: MetadataField', function () {
+  var model, rootScope, scope, WsApi;
+
+  var initializeVariables = function(settings) {
+    inject(function ($rootScope, _WsApi_) {
+      rootScope = $rootScope;
+
+      WsApi = _WsApi_;
+    });
+  };
+
+  var initializeModel = function(settings) {
+    inject(function (MetadataField) {
+      scope = rootScope.$new();
+
+      model = angular.extend(new MetadataField());
+    });
+  };
+
+  beforeEach(function() {
+    module('core');
+    module('sage');
+    module('mock.wsApi');
+
+    initializeVariables();
+    initializeModel();
+  });
+
+  describe('Is the model defined', function () {
+    it('should be defined', function () {
+      expect(model).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Maintain binding for active tab, clone model for modal scope.

Redesign how the first row for FacetFields, SearchFields, and ResultMetadataFields are used by implementing ng-ifs and providing defaults.

Correctly calculate tabs length and make sure the active tab is always valid.
The `$scope.active` was renamed to `$scope.tabs.active` so that the length of tabs could be grouped with the active tab and make calculations consistent.
The number of tabs is 4 and not 3, so set length to 4.

Creating a DiscoveryView now directly handles initializing a default source, if possible, and subsequently loading of the fields.

Implement MetadataField and FacetField models in the UI.

Don't add the default searchField in the scaffold.
Instead, append the default after the scaffold is used so that a new SearchField model can be explicitly created.

The "FacetFields" class is actually a single facet field and should be called "FacetField".

If the select list is changed but ends up on the same source, do not reload the source and break the list key mapping.