### PR TITLE
[D-01285] discovery view error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ng-openseadragon": "1.3.5",
     "ng-table": "3.0.1",
     "openseadragon": "2.4.0",
-    "weaver-ui-core": "git+https://github.com/TAMULib/Weaver-UI-Core.git#v2.0.4"
+    "weaver-ui-core": "git+https://github.com/TAMULib/Weaver-UI-Core.git#v2.0.5"
   },
   "devDependencies": {
     "grunt": "1.0.3",

--- a/src/main/webapp/app/views/modals/confirmDeleteDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/confirmDeleteDiscoveryViewModal.html
@@ -4,6 +4,7 @@
     <h4 class="modal-title">Confirm Removal?</h4>
   </div>
   <div class="modal-body">
+    <alerts seconds="30" channels="discovery-view" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
       <h3>Are you sure you want to remove:</h3>

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -4,7 +4,7 @@
     <h4 class="modal-title">Create Discovery View</h4>
   </div>
   <div class="modal-body">
-    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
+    <alerts seconds="30" channels="source/solr/fields,discovery-view" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -4,7 +4,7 @@
     <h4 class="modal-title">Edit Discovery View</h4>
   </div>
   <div class="modal-body">
-    <alerts seconds="30" channels="source/solr/fields" types="WARNING,ERROR" exclusive></alerts>
+    <alerts seconds="30" channels="source/solr/fields,discovery-view" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="activeJustified" justified="true">


### PR DESCRIPTION
Upgrade to Weaver-UI-2.0.5, which includes relevant fixes/improvements in the error handling.

Catch `discovery-view` channel in Discovery View modals.