### PR TITLE
[B-03916] As a curator, I would like a warning about unavailable sources/destinations (collections/cores) when adding them to new objects

### DIFF
--- a/src/main/java/edu/tamu/sage/controller/SourceController.java
+++ b/src/main/java/edu/tamu/sage/controller/SourceController.java
@@ -1,6 +1,7 @@
 package edu.tamu.sage.controller;
 
 import static edu.tamu.weaver.response.ApiStatus.ERROR;
+import static edu.tamu.weaver.response.ApiStatus.WARNING;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.CREATE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
@@ -53,6 +54,25 @@ public class SourceController {
     private SourceService sourceService;
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @RequestMapping("/test/ping")
+    @PreAuthorize("hasRole('ANONYMOUS')")
+    public ApiResponse testSolrCorePing(@WeaverValidatedModel Source source) throws IOException {
+        SolrClient solr = new HttpSolrClient(source.getUri());
+
+        ApiResponse response = new ApiResponse(SUCCESS);
+
+        try {
+            solr.ping();
+        } catch (Exception e) {
+            logger.info("Failed to ping " + source.getName() + " at URL " + source.getUri() + ", response = " + e.getMessage());
+            response = new ApiResponse(WARNING, "Failed to connect to " + source.getName() + " at URL " + source.getUri());
+        } finally {
+            solr.close();
+        }
+
+        return response;
+    }
 
     @RequestMapping("/test/location")
     @PreAuthorize("hasRole('ANONYMOUS')")

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -51,6 +51,12 @@ var apiMapping = {
       'httpMethod': 'DELETE',
       'method': ''
     },
+    testPing: {
+      'endpoint': '/private/queue',
+      'controller': 'source/solr',
+      'httpMethod': 'POST',
+      'method': 'test/ping'
+    },
     testLocation: {
       'endpoint': '/private/queue',
       'controller': 'source/solr',

--- a/src/main/webapp/app/model/sourceModel.js
+++ b/src/main/webapp/app/model/sourceModel.js
@@ -1,21 +1,27 @@
 // This relates to a "Core", to represent a "Source", the readOnly property of a "Core" needs to be set to TRUE.
-sage.model("Source", function(WsApi, HttpMethodVerbs) {
+sage.model("Source", function($q, WsApi, HttpMethodVerbs) {
   return function Source() {
-    var core = this;
+    var model = this;
 
-    core.testLocation = function(core) {
-      var testLocationPromise = WsApi.fetch(core.getMapping().testLocation, {
-        data: core
+    model.testPing = function() {
+      var promise = WsApi.fetch(model.getMapping().testPing, {
+        data: model
       });
-      return testLocationPromise;
+      return promise;
     };
 
-    core.testAuthorization = function() {
+    model.testLocation = function() {
       return $q(function(resolve) {
         resolve();
       });
     };
 
-    return core;
+    model.testAuthorization = function() {
+      return $q(function(resolve) {
+        resolve();
+      });
+    };
+
+    return model;
   };
 });

--- a/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/createDiscoveryViewModal.html
@@ -4,7 +4,7 @@
     <h4 class="modal-title">Create Discovery View</h4>
   </div>
   <div class="modal-body" ng-if="discoveryView">
-    <alerts seconds="30" channels="source/solr/fields,discovery-view" types="WARNING,ERROR" exclusive></alerts>
+    <alerts seconds="30" channels="source/solr/fields,source/solr/test,discovery-view" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="tabs.active" justified="true">
@@ -48,7 +48,8 @@
               form="discoveryViewForms.create"
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
-              autocomplete="off">
+              autocomplete="off"
+              change="refreshSource(discoveryView)>
             </validatedinput>
 
             <validatedinput

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -4,7 +4,7 @@
     <h4 class="modal-title">Edit Discovery View</h4>
   </div>
   <div class="modal-body" ng-if="discoveryView">
-    <alerts seconds="30" channels="source/solr/fields,discovery-view" types="WARNING,ERROR" exclusive></alerts>
+    <alerts seconds="30" channels="source/solr/fields,source/solr/test,discovery-view" types="WARNING,ERROR" exclusive></alerts>
     <validationmessage results="discoveryViewForms.getResults()"></validationmessage>
 
     <uib-tabset active="tabs.active" justified="true">
@@ -48,7 +48,8 @@
               form="discoveryViewForms.update"
               validations="discoveryViewForms.validations"
               results="discoveryViewForms.getResults()"
-              autocomplete="off">
+              autocomplete="off"
+              change="refreshSource(discoveryView)>
             </validatedinput>
 
             <validatedinput

--- a/src/main/webapp/tests/mocks/model/mockSource.js
+++ b/src/main/webapp/tests/mocks/model/mockSource.js
@@ -31,6 +31,24 @@ var dataSource3 = {
 var mockSource = function($q) {
   var model = mockModel("Source", $q, dataSource1);
 
+  model.testPing = function() {
+    return $q(function(resolve) {
+      resolve();
+    });
+  };
+
+  model.testLocation = function() {
+    return $q(function(resolve) {
+      resolve();
+    });
+  };
+
+  model.testAuthorization = function() {
+    return $q(function(resolve) {
+      resolve();
+    });
+  };
+
   return model;
 };
 

--- a/src/main/webapp/tests/unit/models/sourceModelTest.js
+++ b/src/main/webapp/tests/unit/models/sourceModelTest.js
@@ -1,5 +1,5 @@
 describe('model: Source', function () {
-  var model, rootScope, scope, WsApi;
+  var q, model, rootScope, scope, WsApi;
 
   var initializeVariables = function(settings) {
     inject(function ($rootScope, _WsApi_) {
@@ -10,7 +10,8 @@ describe('model: Source', function () {
   };
 
   var initializeModel = function(settings) {
-    inject(function (Source) {
+    inject(function ($q, Source) {
+      q = $q;
       scope = rootScope.$new();
 
       model = angular.extend(new Source());
@@ -33,6 +34,11 @@ describe('model: Source', function () {
   });
 
   describe('Are the model methods defined', function () {
+    it('testPing should be defined', function () {
+      expect(model.testPing).toBeDefined();
+      expect(typeof model.testPing).toEqual("function");
+    });
+
     it('testLocation should be defined', function () {
       expect(model.testLocation).toBeDefined();
       expect(typeof model.testLocation).toEqual("function");
@@ -45,6 +51,30 @@ describe('model: Source', function () {
   });
 
   describe('Are the model methods working as expected', function () {
-    // @todo
+    it('testPing should work', function () {
+      var passedPath;
+
+      WsApi.fetch = function(path, data) {
+        passedPath = path;
+      };
+
+      spyOn(WsApi, "fetch").and.callThrough();
+
+      model.testPing();
+      scope.$digest();
+
+      expect(WsApi.fetch).toHaveBeenCalled();
+      expect(passedPath.method).toBe("test/ping");
+    });
+
+    it('testLocation should work', function () {
+      model.testLocation();
+      scope.$digest();
+    });
+
+    it('testAuthorization should work', function () {
+      model.testAuthorization();
+      scope.$digest();
+    });
   });
 });


### PR DESCRIPTION
Adds and implements `/source/solr/test/ping` endpoint.
There are also some existing endpoints, but these are currently outdated and do more than is necessary.
Furthermore, the other endpoints produce errors and the "test/ping" endpoint is intended to produce warnings.

The ping (and only a ping) is performed when selecting any given `source` on the first tab in the Discovery View management's first tab.
If the ping fails, a warning is presented to the user.
If the user continues to the next tab despite the warning, an error will be presented as usual when trying to fetch the fields.

The errors should also be presented when the `filter` changes and not just the `source`.