### PR TITLE
Home breadcrumb should always be a link

### DIFF
--- a/src/main/webapp/app/views/directives/breadcrumbs.html
+++ b/src/main/webapp/app/views/directives/breadcrumbs.html
@@ -1,7 +1,7 @@
 <nav ng-if="contexts" ng-init="getBreadcrumbs()" aria-label="Breadcrumbs" class="breadcrumbs">
   <ol class="breadcrumb">
     <li ng-if="home" class="home">
-      <span ng-if="home.active" class="active"><span class="glyphicon glyphicon-home"></span> {{home.label}}</span>
+      <a ng-if="home.active" class="link-like" ng-click="reload()" aria-current="page"><span class="breadcrumb-active glyphicon glyphicon-home"></span> {{home.label}}</a>
       <a ng-if="!home.active" href="{{home.path}}"><span class="glyphicon glyphicon-home"></span> {{home.label}}</a>
     </li>
     <li ng-repeat="breadcrumb in breadcrumbs track by $index">


### PR DESCRIPTION
I had previously designed the breadcrumb to not be a link.
When I managed to get the link to work (using the "reload" design), I forgot to update the link when home.active is TRUE.