### PR TITLE
Test coverage integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+repo: "TAMULib/SAGE"
+
 matrix:
   include:
   - name: "Java Tests"


### PR DESCRIPTION
After "Sage" was renamed to "SAGE", coveralls stopped working.
The Java tests were using "SAGE" and the angularjs tests were using "Sage".
This resulted in the parallel build never completing.

Use "repo" property to manually enforce all uppercase "SAGE".

see: https://docs.travis-ci.com/user/deployment/pages/#further-configuration