### PR TITLE
Restore email registration login functionality

### DIFF
--- a/src/main/webapp/app/controllers/appLoginController.js
+++ b/src/main/webapp/app/controllers/appLoginController.js
@@ -1,6 +1,6 @@
 sage.controller('AppLoginController', function ($controller, $scope) {
 
-  angular.extend(this, $controller('AuthenticationController', {
+  angular.extend(this, $controller('LoginController', {
     $scope: $scope
   }));
 

--- a/src/main/webapp/app/views/modals/loginModal.html
+++ b/src/main/webapp/app/views/modals/loginModal.html
@@ -7,7 +7,7 @@
   </div>
 
   <form name="forms.login" novalidate>
-    <span ng-if="isEmailEnabled()">
+    <span ng-controller="AppLoginController" ng-if="isEmailEnabled()">
       <validationmessage results="user.getValidationResults()"></validationmessage>
       <div class="modal-body loginModal">
         <validatedinput
@@ -34,7 +34,7 @@
         <button class="btn btn-primary" type="submit" ng-click="login()" ng-disabled="forms.login.$invalid">Login</button>
       </div>
     </span>
-    <div class="modal-footer">
+    <div ng-controller="AuthenticationController" class="modal-footer">
       <button type="button" class="btn btn-default" ng-click="reset()">Cancel</button>
       <button ng-if="isExternalEnabled()" type="button" class="btn btn-primary pull-left" ng-click="login()">External Login</button>
     </div>


### PR DESCRIPTION
AppLoginController.js needs to extend  weaver LoginController, not AuthenticationController or the email login functionality is broken due to the different login method implementations.

https://github.com/TAMULib/Weaver-UI-Core/blob/2.x/app/controllers/authenticationController.js#L54

https://github.com/TAMULib/Weaver-UI-Core/blob/2.x/app/controllers/loginController.js#L7