### PR TITLE
[145] Multiple fixes for solr query and facet search

### DIFF
--- a/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
+++ b/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
@@ -7,6 +7,7 @@ import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -84,18 +85,23 @@ public class DiscoveryViewController {
 
     @RequestMapping(value = "/context/{slug}", method = RequestMethod.GET)
     @PreAuthorize("hasRole('ANONYMOUS')")
-    public ApiResponse findBySlug(@PathVariable String slug, @RequestParam(name = "field", defaultValue = "") String field, @RequestParam(name = "value", defaultValue = "") String value, @PageableDefault(page = 0, size = 10) Pageable page, @RequestParam(name = "offset", defaultValue = "0") int offset, @RequestParam Map<String, String> filterMap) throws DiscoveryContextNotFoundException, UnsupportedEncodingException, DiscoveryContextBuildException {
+    public ApiResponse findBySlug(@PathVariable String slug, @RequestParam(name = "field", defaultValue = "") String field, @RequestParam(name = "value", defaultValue = "") String value, @PageableDefault(page = 0, size = 10) Pageable page, @RequestParam(name = "offset", defaultValue = "0") int offset, @RequestParam Map<String, String> reqFilterMap) throws DiscoveryContextNotFoundException, UnsupportedEncodingException, DiscoveryContextBuildException {
         DiscoveryView discoveryView = discoveryViewRepo.findOneBySlug(slug);
         if (discoveryView == null) {
             throw new DiscoveryContextNotFoundException(String.format("Could not find Discovery Context for %s", slug));
         }
 
-        filterMap.remove("field");
-        filterMap.remove("value");
-        filterMap.remove("page");
-        filterMap.remove("size");
-        filterMap.remove("sort");
-        filterMap.remove("offset");
+        reqFilterMap.remove("field");
+        reqFilterMap.remove("value");
+        reqFilterMap.remove("page");
+        reqFilterMap.remove("size");
+        reqFilterMap.remove("sort");
+        reqFilterMap.remove("offset");
+
+        Map<String, String> filterMap = new HashMap<String,String>();
+        reqFilterMap.forEach((k,v) -> {
+           filterMap.put( k.replace("f.", ""), v);
+        });
 
         return new ApiResponse(SUCCESS, solrDiscoveryService.buildDiscoveryContext(discoveryView, field, value, page, offset, filterMap));
     }

--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -16,6 +16,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrQuery.ORDER;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
@@ -80,9 +81,9 @@ public class SolrDiscoveryService {
         if (search.getField().isEmpty() && search.getValue().isEmpty()) {
             query = "*:*";
         } else if (search.getField().isEmpty()) {
-            query = search.getValue();
+            query = ClientUtils.escapeQueryChars(search.getValue());
         } else {
-            query = search.getField() + ":" + search.getValue();
+            query = search.getField() + ":" + ClientUtils.escapeQueryChars(search.getValue());
         }
 
         SolrQuery solrQuery = new SolrQuery(query);
@@ -111,7 +112,7 @@ public class SolrDiscoveryService {
                         filter.setLabel(facetField.getLabel());
                         filter.setValue(filterValues[i]);
                         filters.add(filter);
-                        solrQuery.addFilterQuery(facetField.getKey() + ":" + filterValues[i]);
+                        solrQuery.addFilterQuery(facetField.getKey() + ":" + ClientUtils.escapeQueryChars(filterValues[i]));
                     }
                 }
             });

--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -43,6 +43,7 @@ import edu.tamu.sage.utility.ValueTemplateUtility;
 public class SolrDiscoveryService {
 
     private final static String FILTER_WILDCARD = "*:*";
+    private final static String FILTER_VALUE_PREFIX = "fv::";
 
     private final static Logger logger = LoggerFactory.getLogger(SolrDiscoveryService.class);
 
@@ -102,17 +103,16 @@ public class SolrDiscoveryService {
             discoveryView.getFacetFields().forEach(facetField -> {
                 solrQuery.addFacetField(facetField.getKey());
 
-                String filterKey = "f." + facetField.getKey();
+                String filterKey = facetField.getKey();
                 if (filterMap.containsKey(filterKey)) {
-                    String[] filterValues = filterMap.get(filterKey).split(",", -1);
-
+                    String[] filterValues = filterMap.get(filterKey).split(","+FILTER_VALUE_PREFIX, -1);
                     for (int i = 0; i < filterValues.length; i++) {
                         Filter filter = new Filter();
                         filter.setKey(facetField.getKey());
                         filter.setLabel(facetField.getLabel());
-                        filter.setValue(filterValues[i]);
+                        filter.setValue(filterValues[i].replace(FILTER_VALUE_PREFIX,""));
                         filters.add(filter);
-                        solrQuery.addFilterQuery(facetField.getKey() + ":" + ClientUtils.escapeQueryChars(filterValues[i]));
+                        solrQuery.addFilterQuery(facetField.getKey() + ":" + ClientUtils.escapeQueryChars(filter.getValue()));
                     }
                 }
             });

--- a/src/main/webapp/app/model/discoveryContextModel.js
+++ b/src/main/webapp/app/model/discoveryContextModel.js
@@ -26,9 +26,8 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, Field, Man
         if (!angular.isDefined(parameters.query[filterKey])) {
           parameters.query[filterKey] = [];
         }
-        parameters.query[filterKey].push(filter.value);
+        parameters.query[filterKey].push(encodeURIComponent(filter.value));
       });
-
       return WsApi.fetch(discoveryContext.getMapping().load, parameters);
     };
 

--- a/src/main/webapp/app/model/discoveryContextModel.js
+++ b/src/main/webapp/app/model/discoveryContextModel.js
@@ -26,7 +26,8 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, Field, Man
         if (!angular.isDefined(parameters.query[filterKey])) {
           parameters.query[filterKey] = [];
         }
-        parameters.query[filterKey].push(encodeURIComponent(filter.value));
+        //the service uses the fv:: prefix to understand and process multiple values for the same filter key
+        parameters.query[filterKey].push(encodeURIComponent("fv::"+filter.value));
       });
       return WsApi.fetch(discoveryContext.getMapping().load, parameters);
     };

--- a/src/main/webapp/app/views/discovery/discovery-context.html
+++ b/src/main/webapp/app/views/discovery/discovery-context.html
@@ -33,7 +33,7 @@
         <div class="col-xs-12">
           <ul class="list list-inline">
             <li style="min-width:37px" class="btn btn-primary dc-active-filter" ng-click="resetBadges()"><span class="glyphicon glyphicon-home"></span></li>
-            <li role="presentation" ng-if="hasActiveFilters()" ng-repeat="filter in discoveryContext.search.filters" class="btn btn-primary dc-active-filter" ng-click="removeFilter(filter)"><span class="glyphicon glyphicon-filter"></span>{{filter.label}} <span ng-if="filter.key">:</span> {{filter.value}} <span class="glyphicon glyphicon-remove"></span></li>
+            <li role="presentation" ng-if="hasActiveFilters()" ng-repeat="filter in discoveryContext.search.filters" class="btn btn-primary dc-active-filter" ng-click="removeFilter(filter)"><span class="glyphicon glyphicon-filter"></span>{{filter.label}} <span ng-if="filter.key">:</span> {{filter.value|limitTo:60}}<span ng-if="filter.value.length >= 60">...</span> <span class="glyphicon glyphicon-remove"></span></li>
             <li role="presentation" ng-if="hasSearch()" class="btn btn-primary dc-active-filter" ng-click="resetSearch()"><span class="glyphicon glyphicon-search"></span> <span ng-if="discoveryContext.search.label">{{discoveryContext.search.label}} :</span> </span>{{discoveryContext.search.value}} <span class="glyphicon glyphicon-remove"></span></li>
           </ul>
         </div>


### PR DESCRIPTION
Resolves #145 by:

- Using encodeURIComponent on the filter value parameters before sending them to the server to prevent Tomcat level bad requests

- Using Apache ClientUtils to escape the search and facet values before querying solr

- Introducing a 'fv::' prefix on filter values to enable server side parsing of multiple facet queries against the same facet key. This approach is used because Tomcat only accepts query parameter arrays in the form 'field=value1,value2,value3' and Spring's built in RequestMap serialization doesn't know how to parse a List/Set when nested within a Map.