### PR TITLE
[FOLLOWUP][145] Remove character escaping for solr search, leave in place for facet

### DIFF
--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -82,9 +82,9 @@ public class SolrDiscoveryService {
         if (search.getField().isEmpty() && search.getValue().isEmpty()) {
             query = "*:*";
         } else if (search.getField().isEmpty()) {
-            query = ClientUtils.escapeQueryChars(search.getValue());
+            query = search.getValue();
         } else {
-            query = search.getField() + ":" + ClientUtils.escapeQueryChars(search.getValue());
+            query = search.getField() + ":" + search.getValue();
         }
 
         SolrQuery solrQuery = new SolrQuery(query);


### PR DESCRIPTION
This is a followup PR for PR #162

The current behavior of SAGE before 162 was to accept solr special characters when searching. 

This followup PR restores that behavior.