### PR TITLE
[187] Updates to SimpleProcessor to handle multivalued fields

### DIFF
--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -131,7 +131,7 @@
     <field name="digital_publisher" type="strings" indexed="true" stored="true" multiValued="true"/>
     <field name="rights_access" type="strings" indexed="true" stored="true" multiValued="true"/>
     <field name="reformatting" type="strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="filename" type="sorting_string" indexed="true" stored="true" multiValued="false"/>
+    <field name="filename" type="sorting_string" indexed="true" stored="true" multiValued="true"/>
 
     <copyField source="title" dest="_text_"/>
     <copyField source="title" dest="title_txt_en_split"/>
@@ -154,7 +154,7 @@
     <copyField source="summary_abstract" dest="_text_"/>
     <copyField source="institution_department" dest="_text_"/>
     <copyField source="edition_revision_information" dest="_text_"/>
-    <copyField source="summary_abstract" dest="summary_abstract_txt_en_split"/>
+    <copyField source="summary_abstract" dest="summary_abstract_txt_en_split_mv"/>
 
     <!-- Non-core Recommended -->
     <field name="alternative_title" type="strings" indexed="true" stored="true" multiValued="true"/>
@@ -444,6 +444,8 @@
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
+
+    <dynamicField name="*_txt_en_split_mv" type="text_en_splitting"  indexed="true" stored="true" multiValued="true"/>
 
     <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
          but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->

--- a/src/main/java/edu/tamu/sage/service/SimpleProcessorService.java
+++ b/src/main/java/edu/tamu/sage/service/SimpleProcessorService.java
@@ -84,17 +84,11 @@ public class SimpleProcessorService implements ProcessorService {
 
                     solrReader.getFields().forEach(field -> {
                         if (doc.getFieldValues(field.getName()) != null) {
-                            boolean hasValue = false;
-                            doc.getFieldValues(field.getName()).forEach(result -> {
-                                if (hasValue) {
-                                    return;
-                                }
-                                if (field.getSchemaMapping().equals("terms.identifier") && doc.getFieldValue(field.getName()).toString().contains("://")) {
-                                    resultsMap.put(field.getSchemaMapping(), new String(Base64.encodeBase64(result.toString().getBytes())));
-                                } else {
-                                    resultsMap.put(field.getSchemaMapping(), result);
-                                }
-                            });
+                            if (doc.getFieldValues(field.getName()).size() > 1) {
+                                resultsMap.put(field.getSchemaMapping(), doc.getFieldValues(field.getName()));
+                            } else {
+                                resultsMap.put(field.getSchemaMapping(), doc.getFirstValue(field.getName()));
+                            }
                         }
                     });
 
@@ -186,6 +180,7 @@ public class SimpleProcessorService implements ProcessorService {
      * @param job the job to process
      * @return whether the job has started or not
      */
+    @Override
     public boolean process(Job job) {
         boolean processStarted = false;
         AtomicBoolean processing;
@@ -216,6 +211,7 @@ public class SimpleProcessorService implements ProcessorService {
      *
      * @param jobs list of jobs to process
      */
+    @Override
     public void process(List<Job> jobs) {
         jobs.forEach(job -> process(job));
     }


### PR DESCRIPTION
Resolves #187 by passing through solr doc values that have more than one entry and using the first entry when there is only one value. The UI is already capable of displaying multiValued entries.

Using the first/only entry for single values preserves backwards compatibility with existing operators that assume a single string rather than an ArrayList. We will likely need to modify the operator pipeline to support both multivalued and single string entries at some point.

This PR also removes some dead legacy code from the early days of the aggregation process. 

This PR also updates the docker solr schema by:
- converting 'filename' into a multiValued field
- adding a multiValued dynamic field '*_txt_en_split_mv' to support optional tokenized indexing of multiValued fields
- converting existing 'summary_abstract' copy field to use '*_txt_en_split_mv'