### PR TITLE
[208] hide title in Mirador viewer

### DIFF
--- a/src/main/webapp/app/resources/styles/sass/directives/single-result.scss
+++ b/src/main/webapp/app/resources/styles/sass/directives/single-result.scss
@@ -34,5 +34,9 @@
     position: relative;
   }
 
+  .mirador-container h3.window-manifest-title {
+    display: none;
+  }
+
   margin-bottom: 10px;
 }


### PR DESCRIPTION
Resolves #208 by using css to hide the title altogether because...

The labels in many of our manifests have multiple entries..

Mirador 2.7.x is hard-coded deep in its bowels to add line breaks between multi-valued entries:
https://github.com/ProjectMirador/mirador/blob/v2.7.0/js/src/utils/jsonLd.js#L61

Line breaks are special in CSS. Pseudo classes don't work on them, and the only cross browser option to neutralize them is with display:none. This hides the break, but without pseudo classes, there's no way to add a space between the entries.

There's also no way to turn the title off in 2.7.x.

In currently unreleased 3.x, the [title can be turned off](https://github.com/ProjectMirador/mirador/pull/2630), and 
it looks like [multi-valued entries are handled better too](https://github.com/IIIF-Commons/manifesto/pull/60).
