### PR TITLE
[222][FOLLOWUP] Use simpler regex pattern for urls to avoid full view recursion error

### DIFF
--- a/src/main/webapp/app/directives/presentValueDirective.js
+++ b/src/main/webapp/app/directives/presentValueDirective.js
@@ -3,7 +3,7 @@ sage.directive('presentValue', function() {
     templateUrl: "views/directives/presentValue.html",
     link: function($scope, attr, elem) {
 	  $scope.isUrl = function(value) {
-	    var pattern = new RegExp('^(https?:\\/\\/)?((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|((\\d{1,3}\\.){3}\\d{1,3}))(\\:\\d+)?(\\/[-a-z\\d%_.~+@]*)*(\\?[;&a-z\\d%_.~+=-]*)?(\\#[-a-z\\d_]*)?$', 'i');
+	    var pattern = new RegExp('^(https?:\\/\\/)', 'i');
 	    return pattern.test(value);
 	  };
     }


### PR DESCRIPTION
The more complex url detection regex is leading to too much recursion errors when applied to the id field in full view.

This simpler pattern only checks for the protocol at the start of the string. This matches the card description and doesn't trigger the recursion error.