### PR TITLE
[186] Require facet and search fields to be populated in UI

### DIFF
--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -199,15 +199,44 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
   };
 
   $scope.isDiscoveryViewFacetsInvalid = function(key) {
-    return false;
+    var isInvalid = false;
+    if (angular.isDefined($scope.discoveryView)) {
+      var facetFields = $scope.discoveryView.facetFields;
+      angular.forEach(facetFields, function(field) {
+        if (field === undefined  || !fieldIsPopulated(field,['type'])) {
+          isInvalid = true;
+        }
+      });
+    }
+    return isInvalid;
   };
 
   $scope.isDiscoveryViewSearchInvalid = function(key) {
+    var isInvalid = false;
     if (angular.isDefined($scope.discoveryView)) {
       var searchFields = $scope.discoveryView.searchFields;
-      return (searchFields && (searchFields.$invalid || searchFields.length == 0));
+      if (searchFields && (searchFields.$invalid || searchFields.length == 0)) {
+        isInvalid = true;
+      }
+      angular.forEach(searchFields, function(field) {
+        if (field === undefined || !fieldIsPopulated(field,['type'])) {
+          isInvalid = true;
+        }
+      });
     }
-    return false;
+
+    return isInvalid;
+  };
+
+  var fieldIsPopulated = function(field, exemptions) {
+    var isPopulated = true;
+    var fieldKeys = Object.keys(field);
+    angular.forEach(fieldKeys, function(key) {
+      if ((!exemptions || exemptions.indexOf(key) == -1) && (field[key] == null || field[key] == "" || field[key] == "?")) {
+        isPopulated = false;
+      }
+    });
+    return isPopulated;
   };
 
   $scope.isDiscoveryViewResultsInvalid = function(key) {

--- a/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
+++ b/src/main/webapp/app/views/modals/updateDiscoveryViewModal.html
@@ -345,7 +345,7 @@
     <button type="button" class="btn btn-default" ng-click="cancelUpdateDiscoveryView()">Cancel</button>
     <button ng-show="tabs.active === 0" ng-disabled="isDiscoveryViewGeneralInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
     <button ng-show="tabs.active === 1" type="button" class="btn btn-success" ng-click="back()">Back</button>
-    <button ng-show="tabs.active === 1" ng-disabled="isDiscoveryViewFiltersInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
+    <button ng-show="tabs.active === 1" ng-disabled="isDiscoveryViewFacetsInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
     <button ng-show="tabs.active === 2" type="button" class="btn btn-success" ng-click="back()">Back</button>
     <button ng-show="tabs.active === 2" ng-disabled="isDiscoveryViewSearchInvalid('update')" type="button" class="btn btn-success" ng-click="next()">Next</button>
     <button ng-show="tabs.active === 3" type="button" class="btn btn-success" ng-click="back()">Back</button>


### PR DESCRIPTION
Resolves #186 

Enhances validation for search and facet fields to prevent users from advancing a Discovery View create or update until they fully populate the necessary fields for that widget.

This PR meets the requirements of 186 but is a workaround for an underlying issue that is causing the blank selections in the first place:
https://github.com/TAMULib/SAGE/issues/280

If 280 can be fixed, users won't have a blank option at all.
