### PR TITLE
[266] Presentation for collections with description/info but no logo

### DIFF
--- a/src/main/webapp/app/resources/styles/sass/discovery-context/_all.scss
+++ b/src/main/webapp/app/resources/styles/sass/discovery-context/_all.scss
@@ -11,18 +11,13 @@
     .dc-side-panel {
 
       .information-box {
-        background-size: cover;
         border-radius: 0px;
-        min-height: 440px;
-        position:relative;
 
         .panel-body {
           border-top: 1px solid #8E8E93;
           color:#fff;
           background: rgb(110,110,110);
           background: radial-gradient(circle, rgba(110,110,110,1) 0%, rgba(91,91,91,1) 100%);
-          position: absolute;
-          bottom: 0;
           padding: 5px 12px 10px 15px;
 
           h3 {
@@ -34,6 +29,7 @@
           a {
             color: #fff;
           }
+          width: 100%;
         }
 
         .panel-footer {
@@ -45,6 +41,19 @@
           a {
             color: #fff;
           }
+        }
+
+
+      }
+
+      .logo-information-box {
+        background-size: cover;
+        min-height: 440px;
+        position:relative;
+
+        .panel-body {
+          position: absolute;
+          bottom: 0;
         }
       }
 

--- a/src/main/webapp/app/views/discovery/discovery-context.html
+++ b/src/main/webapp/app/views/discovery/discovery-context.html
@@ -5,7 +5,17 @@
   <div class="dc-content">
     <breadcrumbs contexts="breadcrumbContexts" reload="resetPage" home=""></breadcrumbs>
     <div class="col-md-3 dc-side-panel">
-      <div ng-style="discoveryContext.logoUrl ? {'background-image':'url({{discoveryContext.logoUrl}})'}:{}" ng-if="discoveryContext.infoLinkText || discoveryContext.infoText" class="panel panel-default information-box">
+      <div ng-style="{'background-image':'url({{discoveryContext.logoUrl}})'}" ng-if="discoveryContext.logoUrl && (discoveryContext.infoLinkText || discoveryContext.infoText)" class="panel panel-default information-box logo-information-box">
+        <div ng-if="discoveryContext.infoText" class="panel-body">
+          <h3>
+            <a ng-if="discoveryContext.infoLinkUrl" href="{{discoveryContext.infoLinkUrl}}">{{discoveryContext.infoLinkText}}</a>
+            <span ng-if="!discoveryContext.infoLinkUrl">{{discoveryContext.infoLinkText}}</span>
+          </h3>
+          <div ng-if="discoveryContext.infoText" class="panel-footer" ng-bind-html="presentCollectionText(discoveryContext.infoText)">
+          </div>
+        </div>
+      </div>
+      <div ng-if="!discoveryContext.logoUrl && discoveryContext.infoLinkText" class="panel panel-default information-box">
         <div ng-if="discoveryContext.infoText" class="panel-body">
           <h3>
             <a ng-if="discoveryContext.infoLinkUrl" href="{{discoveryContext.infoLinkUrl}}">{{discoveryContext.infoLinkText}}</a>

--- a/src/main/webapp/app/views/discovery/discovery-context.html
+++ b/src/main/webapp/app/views/discovery/discovery-context.html
@@ -5,8 +5,8 @@
   <div class="dc-content">
     <breadcrumbs contexts="breadcrumbContexts" reload="resetPage" home=""></breadcrumbs>
     <div class="col-md-3 dc-side-panel">
-      <div ng-style="{'background-image':'url({{discoveryContext.logoUrl}})'}" ng-if="discoveryContext.logoUrl && (discoveryContext.infoLinkText || discoveryContext.infoText)" class="panel panel-default information-box logo-information-box">
-        <div ng-if="discoveryContext.infoText" class="panel-body">
+      <div ng-style="{'background-image':'url({{discoveryContext.logoUrl}})'}" ng-if="discoveryContext.logoUrl" class="panel panel-default information-box logo-information-box">
+        <div ng-if="discoveryContext.infoLinkText" class="panel-body">
           <h3>
             <a ng-if="discoveryContext.infoLinkUrl" href="{{discoveryContext.infoLinkUrl}}">{{discoveryContext.infoLinkText}}</a>
             <span ng-if="!discoveryContext.infoLinkUrl">{{discoveryContext.infoLinkText}}</span>
@@ -16,7 +16,7 @@
         </div>
       </div>
       <div ng-if="!discoveryContext.logoUrl && discoveryContext.infoLinkText" class="panel panel-default information-box">
-        <div ng-if="discoveryContext.infoText" class="panel-body">
+        <div class="panel-body">
           <h3>
             <a ng-if="discoveryContext.infoLinkUrl" href="{{discoveryContext.infoLinkUrl}}">{{discoveryContext.infoLinkText}}</a>
             <span ng-if="!discoveryContext.infoLinkUrl">{{discoveryContext.infoLinkText}}</span>


### PR DESCRIPTION
Resolves #266 by adding appropriate presentations for different scenarios:

- When there is a logo and title, the full presentation is shown
- When there is a logo but no title, the logo appears by itself, with no gray box overlay (the description will be ignored, if present).
- When there is no logo but a title, the small gray box from the full presentation is shown, including the description, if available.
- Nothing will display when there is no logo and no title (the description will be ignored, if present).


This PR also corrects the situation where a short title leads to a gray box that fails to cover the full width of the parent logo container.