### PR TITLE
No longer truncating metadata labels

### DIFF
--- a/src/main/webapp/app/resources/styles/sass/directives/single-result.scss
+++ b/src/main/webapp/app/resources/styles/sass/directives/single-result.scss
@@ -30,6 +30,7 @@
 
   .dc-field-key {
     font-weight: bold;
+    white-space: normal;
   }
 
   #mirador-wrapper {

--- a/src/main/webapp/app/resources/styles/sass/discovery-context/_all.scss
+++ b/src/main/webapp/app/resources/styles/sass/discovery-context/_all.scss
@@ -263,6 +263,7 @@
 
                 .dc-field-key {
                   font-weight: bold;
+                  white-space: normal;
                 }
 
                 .dc-field-value {


### PR DESCRIPTION
Resolves #305 

# Discovery Context

## Desktop
![image](https://user-images.githubusercontent.com/11181947/114418287-fb08bf00-9b77-11eb-9443-fc6070d704b4.png)

## Tablet
![image](https://user-images.githubusercontent.com/11181947/114418405-1673ca00-9b78-11eb-995a-63e15797559b.png)

## Mobile
![image](https://user-images.githubusercontent.com/11181947/114418503-2e4b4e00-9b78-11eb-8dac-e2c96da153b7.png)

# Single Item View

## Desktop
![image](https://user-images.githubusercontent.com/11181947/114418688-618ddd00-9b78-11eb-8a60-1103e67e045c.png)

## Tablet
![image](https://user-images.githubusercontent.com/11181947/114418874-8d10c780-9b78-11eb-8a60-2e8e75c7c033.png)

## Mobile
![image](https://user-images.githubusercontent.com/11181947/114419029-b03b7700-9b78-11eb-81fd-bea8c8d2afa7.png)
