### PR TITLE
prevent empty string field mapping on solr document

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <version>1.1</version>

--- a/src/main/java/edu/tamu/sage/service/SimpleProcessorService.java
+++ b/src/main/java/edu/tamu/sage/service/SimpleProcessorService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -135,7 +136,11 @@ public class SimpleProcessorService implements ProcessorService {
                         logger.debug("Writing field: " + outputMapping.getInputField());
                         outputMapping.getMappings().forEach(mapping -> {
                             logger.debug("Indexing metatdata: " + outputMapping.getInputField() + " = '" + map.get(outputMapping.getInputField()) + "' to field: " + mapping);
-                            document.addField(mapping, map.get(outputMapping.getInputField()));
+                            if (StringUtils.isNotEmpty(mapping)) {
+                                document.addField(mapping, map.get(outputMapping.getInputField()));
+                            } else {
+                                logger.warn("Empty field mapping for field {}", outputMapping.getInputField());
+                            }
                         });
                     } else {
                         logger.debug("Skipping field: " + outputMapping.getInputField());


### PR DESCRIPTION
```
org.apache.solr.client.solrj.impl.HttpSolrClient$RemoteSolrException: Error from server at https://api-dev.library.tamu.edu/solr/sage-core: ERROR: [doc=aHR0cHM6Ly9hcGktZGV2LmxpYnJhcnkudGFtdS5lZHUvZmNyZXBvL3Jlc3QvYS10aW1lLW9mLXJlc29sdmUtMjAyMC0wNC0zMF9vYmplY3RzLzEwMw==] unknown field ''
	at org.apache.solr.client.solrj.impl.HttpSolrClient.executeMethod(HttpSolrClient.java:577)
	at org.apache.solr.client.solrj.impl.HttpSolrClient.request(HttpSolrClient.java:241)
	at org.apache.solr.client.solrj.impl.HttpSolrClient.request(HttpSolrClient.java:230)
	at org.apache.solr.client.solrj.SolrRequest.process(SolrRequest.java:149)
	at org.apache.solr.client.solrj.SolrClient.add(SolrClient.java:106)
	at org.apache.solr.client.solrj.SolrClient.add(SolrClient.java:71)
	at org.apache.solr.client.solrj.SolrClient.add(SolrClient.java:85)
	at edu.tamu.sage.service.SimpleProcessorService.writeSolrCore(SimpleProcessorService.java:158)
	at edu.tamu.sage.service.SimpleProcessorService.lambda$process$6(SimpleProcessorService.java:194)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at edu.tamu.sage.service.SimpleProcessorService.lambda$process$7(SimpleProcessorService.java:194)
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1626)
	at java.lang.Thread.run(Thread.java:748)
```