### PR TITLE
[399] Fix npm build by upgrading to Mirador 3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ module.exports = function (grunt) {
           "node_modules/openseadragon/build/openseadragon/openseadragon.min.js",
           "node_modules/ng-openseadragon/build/angular-openseadragon.js",
 
-          "node_modules/mirador/dist/mirador.js"
+          "node_modules/mirador/dist/mirador.min.js"
         ],
         dest: "<%= build.app %>/resources/scripts/vendor_concat.js"
       },
@@ -196,25 +196,12 @@ module.exports = function (grunt) {
     },
 
     copy: {
-      styles: {
-        files: [{
-          cwd: "node_modules/mirador/dist/css/",
-          src: "mirador-combined.min.css",
-          dest: "<%= build.app %>/resources/styles/",
-          expand: true
-        }]
-      },
       fonts: {
         files: [{
           src: [
             "node_modules/bootstrap-sass/assets/fonts/bootstrap/*"
           ],
           dest: "<%= build.app %>",
-          expand: true
-        }, {
-          cwd: "node_modules/mirador/dist/fonts/",
-          src: "*",
-          dest: "<%= build.app %>/resources/fonts/",
           expand: true
         }],
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -238,13 +238,13 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks("grunt-contrib-symlink");
   grunt.loadNpmTasks("grunt-karma-coveralls");
 
-  grunt.registerTask("default", ["jshint", "copy:styles", "copy:fonts", "clean", "symlink"]);
+  grunt.registerTask("default", ["jshint", "copy:fonts", "clean", "symlink"]);
 
-  grunt.registerTask("coverage", ["jshint", "copy:styles", "copy:fonts", "symlink", "coveralls"]);
+  grunt.registerTask("coverage", ["jshint", "copy:fonts", "symlink", "coveralls"]);
 
   grunt.registerTask("watch", ["watch"]);
 
-  grunt.registerTask("develop", ["jshint", "concat", "usemin", "copy:styles", "copy:fonts", "clean", "symlink", "watch"]);
+  grunt.registerTask("develop", ["jshint", "concat", "usemin", "copy:fonts", "clean", "symlink", "watch"]);
 
   grunt.registerTask("deploy", ["jshint", "concat", "uglify", "usemin", "clean", "copy"]);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@wvr/core": "2.2.0",
-    "sanitize-html": "1.13.0",
     "mirador": "3.3.0",
     "ng-csv": "0.3.6",
     "ng-file-upload": "12.2.13",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@wvr/core": "2.2.0",
-    "mirador": "2.7.2",
+    "sanitize-html": "1.13.0",
+    "mirador": "3.3.0",
     "ng-csv": "0.3.6",
     "ng-file-upload": "12.2.13",
     "ng-openseadragon": "1.3.5",

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -22,7 +22,6 @@
   <meta name="description" content="Fedora User Interface" />
 
   <link rel="stylesheet" th:href="${@environment.getProperty('app.url')+'/wro/app.css'}" />
-  <link rel="stylesheet" type="text/css" href="resources/styles/mirador-combined.min.css">
 
 </head>
 
@@ -114,7 +113,8 @@
   <script src="node_modules/openseadragon/build/openseadragon/openseadragon.min.js"></script>
   <script src="node_modules/ng-openseadragon/build/angular-openseadragon.js"></script>
 
-  <script src="node_modules/mirador/dist/mirador.js"></script>
+  <script src="node_modules/mirador/dist/mirador.min.js"></script>
+
   <!-- Core Libraries -->
 
   <!-- Core Configuration -->

--- a/src/main/webapp/app/directives/contentViewerDirective.js
+++ b/src/main/webapp/app/directives/contentViewerDirective.js
@@ -28,28 +28,26 @@ sage.directive("contentviewer", function($filter, $sce, appConfig) {
         $scope.options.prefixUrl = 'resources/images/';
         $scope.options.tileSources = [$scope.resource];
       }
-     
+
       if (viewerTemplate === 'mirador') {
         $scope.loadViewer = function () {
           Mirador.viewer({
             id: 'mirador-wrapper',
-            manifests: [{
-              manifestUri: $scope.resource,
-              location: "TAMU"
-            }],
-            mainMenuSettings: {
-              show: false
+            window: {
+              allowClose: false,
+              allowFullscreen: true,
+              hideWindowTitle: true,
+              sideBarOpen: false
             },
             windows: [{
-              loadedManifest: $scope.resource,
-              viewType: 'ImageView',
-              displayLayout: false,
-              bottomPanel: true,
-              bottomPanelAvailable: false,
-              bottomPanelVisible: false,
-              sidePanel: false,
-              annotationLayer: false
-            }]
+              manifestId: $scope.resource
+             }],
+            workspaceControlPanel: {
+              enabled: false
+            },
+            workspace: {
+              showZoomControls: true
+            }
           });
         };
       }

--- a/src/main/webapp/app/directives/contentViewerDirective.js
+++ b/src/main/webapp/app/directives/contentViewerDirective.js
@@ -31,16 +31,16 @@ sage.directive("contentviewer", function($filter, $sce, appConfig) {
      
       if (viewerTemplate === 'mirador') {
         $scope.loadViewer = function () {
-          Mirador({
+          Mirador.viewer({
             id: 'mirador-wrapper',
-            data: [{ 
+            manifests: [{
               manifestUri: $scope.resource,
               location: "TAMU"
             }],
             mainMenuSettings: {
               show: false
             },
-            windowObjects: [{
+            windows: [{
               loadedManifest: $scope.resource,
               viewType: 'ImageView',
               displayLayout: false,


### PR DESCRIPTION
Resolves #399 

I've adjusted the Mirador 3 settings to bring us closer to the existing Mirador 2 presentation.

The main difference is that Mirador 2 provided a GUI for image manipulation (rotation, saturation, brightness, etc) that passed through to its OpenSeaDragon embed that was visible by default. Mirador 3 doesn't seem to provide that GUI at all, and plugins would be required to recreate that functionality.