### PR TITLE
[399] Fix build by integrating with Mirador 3 + Image Tools Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ node_modules/
 
 .DS_Store
 package-lock.json
+
+src/main/webapp/app/resources/js/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ module.exports = function (grunt) {
           "node_modules/openseadragon/build/openseadragon/openseadragon.min.js",
           "node_modules/ng-openseadragon/build/angular-openseadragon.js",
 
-          "node_modules/mirador/dist/mirador.js"
+          "node_modules/mirador/dist/mirador.min.js"
         ],
         dest: "<%= build.app %>/resources/scripts/vendor_concat.js"
       },
@@ -196,25 +196,12 @@ module.exports = function (grunt) {
     },
 
     copy: {
-      styles: {
-        files: [{
-          cwd: "node_modules/mirador/dist/css/",
-          src: "mirador-combined.min.css",
-          dest: "<%= build.app %>/resources/styles/",
-          expand: true
-        }]
-      },
       fonts: {
         files: [{
           src: [
             "node_modules/bootstrap-sass/assets/fonts/bootstrap/*"
           ],
           dest: "<%= build.app %>",
-          expand: true
-        }, {
-          cwd: "node_modules/mirador/dist/fonts/",
-          src: "*",
-          dest: "<%= build.app %>/resources/fonts/",
           expand: true
         }],
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,6 @@
 module.exports = function (grunt) {
+  const path = require('path');
+  const webpack = require('webpack');
 
   // Configurable paths
   var build = {
@@ -74,9 +76,8 @@ module.exports = function (grunt) {
           "node_modules/file-saver/FileSaver.min.js",
 
           "node_modules/openseadragon/build/openseadragon/openseadragon.min.js",
-          "node_modules/ng-openseadragon/build/angular-openseadragon.js",
+          "node_modules/ng-openseadragon/build/angular-openseadragon.js"
 
-          "node_modules/mirador/dist/mirador.min.js"
         ],
         dest: "<%= build.app %>/resources/scripts/vendor_concat.js"
       },
@@ -224,10 +225,31 @@ module.exports = function (grunt) {
         coverageDir: "src/main/webapp/coverage/",
         dryRun: true
       }
+    },
+    webpack: {
+      mdConfig: {
+        entry: path.resolve('./src/main/webapp/build-js/TAMUMirador.src.js'),
+        mode: 'production',
+        output: {
+          filename: 'TAMUMirador.js',
+          path: path.resolve('./src/main/webapp/app/resources/js/'),
+          library: 'TAMUMirador',
+          libraryTarget: "var"
+        },
+        plugins: [
+          new webpack.IgnorePlugin({
+            resourceRegExp: /@blueprintjs\/(core|icons)/, // ignore optional UI framework dependencies
+          }),
+          new webpack.optimize.LimitChunkCountPlugin({
+            maxChunks: 1
+          })
+        ]
+      }
     }
 
   });
 
+  grunt.loadNpmTasks("grunt-webpack");
   grunt.loadNpmTasks("grunt-usemin");
   grunt.loadNpmTasks("grunt-contrib-copy");
   grunt.loadNpmTasks("grunt-contrib-clean");
@@ -238,14 +260,14 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks("grunt-contrib-symlink");
   grunt.loadNpmTasks("grunt-karma-coveralls");
 
-  grunt.registerTask("default", ["jshint", "copy:fonts", "clean", "symlink"]);
+  grunt.registerTask("default", ["webpack", "jshint", "copy:fonts", "clean", "symlink"]);
 
-  grunt.registerTask("coverage", ["jshint", "copy:fonts", "symlink", "coveralls"]);
+  grunt.registerTask("coverage", ["webpack", "jshint", "copy:fonts", "symlink", "coveralls"]);
 
   grunt.registerTask("watch", ["watch"]);
 
-  grunt.registerTask("develop", ["jshint", "concat", "usemin", "copy:fonts", "clean", "symlink", "watch"]);
+  grunt.registerTask("develop", ["webpack", "jshint", "concat", "usemin", "copy:fonts", "clean", "symlink", "watch"]);
 
-  grunt.registerTask("deploy", ["jshint", "concat", "uglify", "usemin", "clean", "copy"]);
+  grunt.registerTask("deploy", ["webpack", "jshint", "concat", "uglify", "usemin", "clean", "copy"]);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -238,13 +238,13 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks("grunt-contrib-symlink");
   grunt.loadNpmTasks("grunt-karma-coveralls");
 
-  grunt.registerTask("default", ["jshint", "copy:styles", "copy:fonts", "clean", "symlink"]);
+  grunt.registerTask("default", ["jshint", "copy:fonts", "clean", "symlink"]);
 
-  grunt.registerTask("coverage", ["jshint", "copy:styles", "copy:fonts", "symlink", "coveralls"]);
+  grunt.registerTask("coverage", ["jshint", "copy:fonts", "symlink", "coveralls"]);
 
   grunt.registerTask("watch", ["watch"]);
 
-  grunt.registerTask("develop", ["jshint", "concat", "usemin", "copy:styles", "copy:fonts", "clean", "symlink", "watch"]);
+  grunt.registerTask("develop", ["jshint", "concat", "usemin", "copy:fonts", "clean", "symlink", "watch"]);
 
   grunt.registerTask("deploy", ["jshint", "concat", "uglify", "usemin", "clean", "copy"]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -153,7 +153,7 @@ module.exports = function (grunt) {
           "<%= build.app %>/**/*.js",
           "!<%= build.app %>/config/appConfig.js",
           "!<%= build.app %>/config/apiMapping.js",
-          "!<%= build.app %>/resources/**/*",
+          "!<%= build.app %>/resources/scripts/*",
           "!<%= build.app %>/node_modules/**/*"
         ],
         dest: "<%= build.app %>/resources/scripts/app_concat.js"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@wvr/core": "2.2.0",
-    "sanitize-html": "1.13.0",
     "mirador": "3.3.0",
     "ng-csv": "0.3.6",
     "ng-file-upload": "12.2.13",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@wvr/core": "2.2.0",
-    "mirador": "2.7.2",
+    "sanitize-html": "1.13.0",
+    "mirador": "3.3.0",
     "ng-csv": "0.3.6",
     "ng-file-upload": "12.2.13",
     "ng-openseadragon": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,15 @@
   },
   "dependencies": {
     "@wvr/core": "2.2.0",
-    "mirador": "3.3.0",
+    "mirador": "^3.0.0",
+    "mirador-image-tools": "^0.10.0",
     "ng-csv": "0.3.6",
     "ng-file-upload": "12.2.13",
     "ng-openseadragon": "1.3.5",
     "ng-table": "3.0.1",
-    "openseadragon": "2.4.2"
+    "openseadragon": "2.4.2",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "grunt": "1.0.3",
@@ -44,6 +47,7 @@
     "grunt-karma-coveralls": "2.5.4",
     "grunt-ngdocs": "0.2.11",
     "grunt-usemin": "3.1.1",
+    "grunt-webpack": "4.0.3",
     "http-server": "0.11.1",
     "jasmine-core": "3.5.0",
     "jasmine-promise-matchers": "2.6.0",
@@ -56,6 +60,7 @@
     "karma-junit-reporter": "2.0.1",
     "karma-ng-html2js-preprocessor": "1.0.0",
     "protractor": "5.4.2",
-    "uglify-js": "^3.14.4"
+    "uglify-js": "^3.14.4",
+    "webpack": "^4.43.0"
   }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -113,8 +113,6 @@
   <script src="node_modules/openseadragon/build/openseadragon/openseadragon.min.js"></script>
   <script src="node_modules/ng-openseadragon/build/angular-openseadragon.js"></script>
 
-  <script src="node_modules/mirador/dist/mirador.min.js"></script>
-
   <!-- Core Libraries -->
 
   <!-- Core Configuration -->
@@ -268,9 +266,11 @@
   <script src="controllers/singleResultController.js"></script>
   <script src="controllers/usersController.js"></script>
   <script src="controllers/appLoginController.js"></script>
+
+  <script src="resources/js/TAMUMirador.js"></script>
   <!-- endbuild -->
 
-  <!-- CDN tl-component -->
+   <!-- CDN tl-component -->
   <script src="https://labs.library.tamu.edu/tl-components/latest/tl-components.js"></script>
 
 </body>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -22,7 +22,6 @@
   <meta name="description" content="Fedora User Interface" />
 
   <link rel="stylesheet" th:href="${@environment.getProperty('app.url')+'/wro/app.css'}" />
-  <link rel="stylesheet" type="text/css" href="resources/styles/mirador-combined.min.css">
 
 </head>
 
@@ -114,7 +113,8 @@
   <script src="node_modules/openseadragon/build/openseadragon/openseadragon.min.js"></script>
   <script src="node_modules/ng-openseadragon/build/angular-openseadragon.js"></script>
 
-  <script src="node_modules/mirador/dist/mirador.js"></script>
+  <script src="node_modules/mirador/dist/mirador.min.js"></script>
+
   <!-- Core Libraries -->
 
   <!-- Core Configuration -->

--- a/src/main/webapp/app/directives/contentViewerDirective.js
+++ b/src/main/webapp/app/directives/contentViewerDirective.js
@@ -28,28 +28,26 @@ sage.directive("contentviewer", function($filter, $sce, appConfig) {
         $scope.options.prefixUrl = 'resources/images/';
         $scope.options.tileSources = [$scope.resource];
       }
-     
+
       if (viewerTemplate === 'mirador') {
         $scope.loadViewer = function () {
           Mirador.viewer({
             id: 'mirador-wrapper',
-            manifests: [{
-              manifestUri: $scope.resource,
-              location: "TAMU"
-            }],
-            mainMenuSettings: {
-              show: false
+            window: {
+              allowClose: false,
+              allowFullscreen: true,
+              hideWindowTitle: true,
+              sideBarOpen: false
             },
             windows: [{
-              loadedManifest: $scope.resource,
-              viewType: 'ImageView',
-              displayLayout: false,
-              bottomPanel: true,
-              bottomPanelAvailable: false,
-              bottomPanelVisible: false,
-              sidePanel: false,
-              annotationLayer: false
-            }]
+              manifestId: $scope.resource
+             }],
+            workspaceControlPanel: {
+              enabled: false
+            },
+            workspace: {
+              showZoomControls: true
+            }
           });
         };
       }

--- a/src/main/webapp/app/directives/contentViewerDirective.js
+++ b/src/main/webapp/app/directives/contentViewerDirective.js
@@ -31,16 +31,16 @@ sage.directive("contentviewer", function($filter, $sce, appConfig) {
      
       if (viewerTemplate === 'mirador') {
         $scope.loadViewer = function () {
-          Mirador({
+          Mirador.viewer({
             id: 'mirador-wrapper',
-            data: [{ 
+            manifests: [{
               manifestUri: $scope.resource,
               location: "TAMU"
             }],
             mainMenuSettings: {
               show: false
             },
-            windowObjects: [{
+            windows: [{
               loadedManifest: $scope.resource,
               viewType: 'ImageView',
               displayLayout: false,

--- a/src/main/webapp/app/directives/contentViewerDirective.js
+++ b/src/main/webapp/app/directives/contentViewerDirective.js
@@ -31,24 +31,7 @@ sage.directive("contentviewer", function($filter, $sce, appConfig) {
 
       if (viewerTemplate === 'mirador') {
         $scope.loadViewer = function () {
-          Mirador.viewer({
-            id: 'mirador-wrapper',
-            window: {
-              allowClose: false,
-              allowFullscreen: true,
-              hideWindowTitle: true,
-              sideBarOpen: false
-            },
-            windows: [{
-              manifestId: $scope.resource
-             }],
-            workspaceControlPanel: {
-              enabled: false
-            },
-            workspace: {
-              showZoomControls: true
-            }
-          });
+          TAMUMirador.getMirador("mirador-wrapper", $scope.resource);
         };
       }
 

--- a/src/main/webapp/app/directives/contentViewerDirective.js
+++ b/src/main/webapp/app/directives/contentViewerDirective.js
@@ -31,8 +31,15 @@ sage.directive("contentviewer", function($filter, $sce, appConfig) {
 
       if (viewerTemplate === 'mirador') {
         $scope.loadViewer = function () {
-          TAMUMirador.getMirador("mirador-wrapper", $scope.resource);
+          const tamuMirador = TAMUMirador.getInstance();
+          tamuMirador.initialize("mirador-wrapper");
+          tamuMirador.addWindow($scope.resource);
+
+          $scope.$on("$destroy", function() {
+            tamuMirador.destroy();
+          });
         };
+
       }
 
       if (viewerTemplate === 'avalon') {

--- a/src/main/webapp/build-js/TAMUMirador.src.js
+++ b/src/main/webapp/build-js/TAMUMirador.src.js
@@ -1,0 +1,28 @@
+import Mirador from '../../../../node_modules/mirador/dist/es/src/index';
+import { miradorImageToolsPlugin } from '../../../../node_modules/mirador-image-tools/es/index';
+
+var getMirador = function (domId, manifestId) {
+        Mirador.viewer({
+            id: domId,
+            window: {
+              allowClose: false,
+              allowFullscreen: true,
+              hideWindowTitle: true,
+              sideBarOpen: false
+            },
+            windows: [{
+              manifestId: manifestId,
+              imageToolsEnabled: true,
+              imageToolsOpen: false
+            }],
+            workspaceControlPanel: {
+              enabled: false
+            },
+            workspace: {
+              showZoomControls: true
+            }
+          },
+          [...miradorImageToolsPlugin]);
+};
+
+export { getMirador }

--- a/src/main/webapp/build-js/TAMUMirador.src.js
+++ b/src/main/webapp/build-js/TAMUMirador.src.js
@@ -1,5 +1,4 @@
 import Mirador from '../../../../node_modules/mirador/dist/es/src/index';
-import MiradorViewer from '../../../../node_modules/mirador/dist/es/src/lib/MiradorViewer';
 import { miradorImageToolsPlugin } from '../../../../node_modules/mirador-image-tools/es/index';
 
 var getInstance = function() {
@@ -9,23 +8,23 @@ var getInstance = function() {
   return {
       initialize: function (domId) {
         if (_miradorInstance == null) {
-          _miradorInstance = new MiradorViewer({
-                id: domId,
-                window: {
-                  allowClose: false,
-                  allowFullscreen: true,
-                  hideWindowTitle: true,
-                  sideBarOpen: false
-                },
-                windows: [],
-                workspaceControlPanel: {
-                  enabled: false
-                },
-                workspace: {
-                  showZoomControls: true
-                }
-              },
-              { plugins: [miradorImageToolsPlugin]});
+          _miradorInstance = Mirador.viewer({
+            id: domId,
+            window: {
+              allowClose: false,
+              allowFullscreen: true,
+              hideWindowTitle: true,
+              sideBarOpen: false
+            },
+            windows: [],
+            workspaceControlPanel: {
+              enabled: false
+            },
+            workspace: {
+              showZoomControls: true
+            }
+          }, [miradorImageToolsPlugin]);
+
         }
       },
       addWindow: function (manifestId) {

--- a/src/main/webapp/build-js/TAMUMirador.src.js
+++ b/src/main/webapp/build-js/TAMUMirador.src.js
@@ -1,28 +1,46 @@
 import Mirador from '../../../../node_modules/mirador/dist/es/src/index';
+import MiradorViewer from '../../../../node_modules/mirador/dist/es/src/lib/MiradorViewer';
 import { miradorImageToolsPlugin } from '../../../../node_modules/mirador-image-tools/es/index';
 
-var getMirador = function (domId, manifestId) {
-        Mirador.viewer({
-            id: domId,
-            window: {
-              allowClose: false,
-              allowFullscreen: true,
-              hideWindowTitle: true,
-              sideBarOpen: false
-            },
-            windows: [{
-              manifestId: manifestId,
-              imageToolsEnabled: true,
-              imageToolsOpen: false
-            }],
-            workspaceControlPanel: {
-              enabled: false
-            },
-            workspace: {
-              showZoomControls: true
-            }
-          },
-          [...miradorImageToolsPlugin]);
-};
+var getInstance = function() {
 
-export { getMirador }
+  var _miradorInstance = null;
+
+  return {
+      initialize: function (domId) {
+        if (_miradorInstance == null) {
+          _miradorInstance = new MiradorViewer({
+                id: domId,
+                window: {
+                  allowClose: false,
+                  allowFullscreen: true,
+                  hideWindowTitle: true,
+                  sideBarOpen: false
+                },
+                windows: [],
+                workspaceControlPanel: {
+                  enabled: false
+                },
+                workspace: {
+                  showZoomControls: true
+                }
+              },
+              { plugins: [miradorImageToolsPlugin]});
+        }
+      },
+      addWindow: function (manifestId) {
+        if (_miradorInstance != null) {
+          let action = Mirador.actions.addWindow({manifestId: manifestId, imageToolsEnabled: true, imageToolsOpen: false});
+          _miradorInstance.store.dispatch(action);
+        }
+      },
+      destroy: function () {
+        if (_miradorInstance != null) {
+          _miradorInstance.unmount();
+          _miradorInstance = null;
+        }
+      }
+    };
+}
+
+export { getInstance }


### PR DESCRIPTION
This PR resolves #399 by manually building Mirador 3 with grunt-webpack to enable packaging the image tools plugin and potentially other future plugins.

This required the implementation of a wrapper object to provide access to Mirador's state while in the context of the angularjs app.

The destroy method in particular is needed to properly unmount the Mirador instance when the contentViewer directive is unloaded by angularjs. This is necessary to prevent rendering issues if a user navigates to another Mirador based discovery view.

This solution appears to be working without issue, but I couldn't find any documented examples of dynamically generating and destroying Mirador instances. The 'proper' use of Mirador 3 seems to be loading one instance and then using redux actions to update it as needed.

We are using redux actions to manipulate the state of the Mirador instance, but due to angularjs's dom element manipulation, we can't sanely preserve a single instance across user navigation.

This wrapper does provide a good starting point for a more generalized component that's not specific to SAGE.

