### PR TITLE
Github is now the default and anonymous git:// urls are no longer supported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-jshint": "2.0.0",
     "grunt-contrib-symlink": "1.0.0",
     "grunt-contrib-uglify": "4.0.0",
-    "grunt-contrib-uglify-es": "git://github.com/gruntjs/grunt-contrib-uglify.git#harmony",
+    "grunt-contrib-uglify-es": "gruntjs/grunt-contrib-uglify.git#harmony",
     "grunt-contrib-watch": "1.1.0",
     "grunt-karma-coveralls": "2.5.4",
     "grunt-ngdocs": "0.2.11",


### PR DESCRIPTION
NPM now handles github as the default.
There may be compatibility concerns with older versions of node/npm.

This has been tested to work under:
- npm 6.14.15
- node v14.18.1