### PR TITLE
Using the delete method, not deleteById, for ws broadcast

### DIFF
--- a/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
+++ b/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
@@ -85,7 +85,7 @@ public class DiscoveryViewController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse deleteDiscoveryView(@RequestBody DiscoveryView discoveryView) {
         logger.info("Deleting Discovery View: " + discoveryView.getName());
-        discoveryViewRepo.deleteById(discoveryView.getId());
+        discoveryViewRepo.delete(discoveryView);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/IternalMetadataController.java
+++ b/src/main/java/edu/tamu/sage/controller/IternalMetadataController.java
@@ -58,7 +58,7 @@ public class IternalMetadataController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse deleteInternalMetadatum(@WeaverValidatedModel InternalMetadata internalMetadatum) {
         logger.info(String.format("Deleting internal metadatum %s with field %s", internalMetadatum.getGloss(), internalMetadatum.getField()));
-        internalMetadataRepo.deleteById(internalMetadatum.getId());
+        internalMetadataRepo.delete(internalMetadatum);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/JobController.java
+++ b/src/main/java/edu/tamu/sage/controller/JobController.java
@@ -65,7 +65,7 @@ public class JobController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse deleteReader(@WeaverValidatedModel Job job) {
         logger.info(String.format("Deleting job %s", job.getName()));
-        jobRepo.deleteById(job.getId());
+        jobRepo.delete(job);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/OperatorController.java
+++ b/src/main/java/edu/tamu/sage/controller/OperatorController.java
@@ -77,7 +77,7 @@ public class OperatorController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE, joins = Job.class, path = "operators") })
     public ApiResponse deleteInternalMetadatum(@WeaverValidatedModel BaseOp operator) {
         logger.info(String.format("Deleting operator %s of type %s", operator.getName(), operator.getType()));
-        operatorRepo.deleteById(operator.getId());
+        operatorRepo.delete(operator);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/ReaderController.java
+++ b/src/main/java/edu/tamu/sage/controller/ReaderController.java
@@ -55,7 +55,7 @@ public class ReaderController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse deleteReader(@WeaverValidatedModel Reader solrReader) {
         logger.info("Deleting Reader: " + solrReader.getName());
-        solrReaderRepo.deleteById(solrReader.getId());
+        solrReaderRepo.delete(solrReader);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/SourceController.java
+++ b/src/main/java/edu/tamu/sage/controller/SourceController.java
@@ -174,7 +174,7 @@ public class SourceController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse deleteSolrCore(@WeaverValidatedModel Source source) {
         logger.info("Deleting Source: " + source.getName());
-        sourceRepo.deleteById(source.getId());
+        sourceRepo.delete(source);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/UserController.java
+++ b/src/main/java/edu/tamu/sage/controller/UserController.java
@@ -95,7 +95,7 @@ public class UserController {
     @RequestMapping("/delete")
     @PreAuthorize("hasRole('MANAGER')")
     public ApiResponse delete(@RequestBody User user) throws Exception {
-        userRepo.deleteById(user.getId());
+        userRepo.delete(user);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/edu/tamu/sage/controller/WriterController.java
+++ b/src/main/java/edu/tamu/sage/controller/WriterController.java
@@ -55,7 +55,7 @@ public class WriterController {
     @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse deleteWriter(@WeaverValidatedModel Writer solrWriter) {
         logger.info("Deleting Writer: " + solrWriter.getName());
-        solrWriterRepo.deleteById(solrWriter.getId());
+        solrWriterRepo.delete(solrWriter);
         return new ApiResponse(SUCCESS);
     }
 }


### PR DESCRIPTION
# Description

Each of the controllers were implementing their delete functionality using `deleteById`. This method does not result in a broadcast to the front end. By replacing each of those method calls with the `delete` method, the broadcast occurs and the lists in the UI are update on delete.

Fixes #457 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual Locally Testing
- [X] Local Automated Testing
- [ ] Manual Dev Testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

