### PR TITLE
Alter sequence if exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ dist/
 
 !**/src/main/**
 !**/src/test/**
+
+*.mv.db

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,8 @@ spring:
 
     # h2
     driverClassName: org.h2.Driver
-    url: jdbc:h2:mem:AZ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:AZ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL
+    # url: jdbc:h2:./sage;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL
 
     # PostgreSQL
     # driverClassName: org.postgresql.Driver

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -14,7 +14,7 @@ INSERT INTO INTERNAL_METADATA SELECT * FROM (
   SELECT 10, 'rightsAccess', 'Rights/Access (dc.rights, dcterms.terms)', false UNION
   SELECT 11, 'reformatting', 'Reformatting (dc.format, dcterms.formats)', false UNION
   SELECT 12, 'filename', 'Filename (dc.identifier, ebucore.filename)', false UNION
-  
+
   SELECT 13, 'subject', 'Subject (dc.subject, dcterms.subject)', false UNION
   SELECT 14, 'creator', 'Creator (dc.creator, dcterms.creator)', false UNION
   SELECT 15, 'datePublished', 'Date Published (dcterms.dateAccepted)', false UNION
@@ -25,7 +25,7 @@ INSERT INTO INTERNAL_METADATA SELECT * FROM (
   SELECT 20, 'standardDigitalIdentifier', 'Standard Digital Identifier (dc.identifier)', false UNION
   SELECT 21, 'localDigitalIdentifier', 'Local Digital Identifier (dc.identifier)', false UNION
   SELECT 22, 'editionRevisionInformation', 'Edition/Revision Information (dc.description, dcterms.hasVersion)', false UNION
-  
+
   SELECT 23, 'alternativeTitle', 'Alternative Title (dcterms.alternative)', false UNION
   SELECT 24, 'genre', 'Genre (dc.type)', false UNION
   SELECT 25, 'tableOfContents', 'Table of Contents (dcterms.tableOfContents)', false UNION
@@ -34,7 +34,7 @@ INSERT INTO INTERNAL_METADATA SELECT * FROM (
   SELECT 28, 'originalPublisher', 'Original Publisher (dc.publisher)', false UNION
   SELECT 29, 'physicalExtent', 'Physical Extent (dcterms.extent)', false UNION
   SELECT 30, 'sponsor', 'Sponsor (dc.contributor, dc.description)', false UNION
-  
+
   SELECT 31, 'sourceCollection', 'Source Collection (dc.relation, dcterms.relation)', false UNION
   SELECT 32, 'originalResource', 'Original Resource (dc.source, dcterms.source)', false UNION
   SELECT 33, 'notes', 'Notes (dc.description, dc.provenance)', false UNION
@@ -49,4 +49,4 @@ INSERT INTO INTERNAL_METADATA SELECT * FROM (
 
 ) M WHERE NOT EXISTS(SELECT * FROM INTERNAL_METADATA);
 
-ALTER SEQUENCE internal_metadata_id_seq RESTART WITH 42;
+ALTER SEQUENCE IF EXISTS internal_metadata_id_seq RESTART WITH 42;


### PR DESCRIPTION
Works with h2 memory and file, postgres locally and in docker.

```
version: '3.7'

networks:
 weaver:

services:

  db:
    image: postgres:10.22-alpine
    environment:
      POSTGRES_USER: sage
      POSTGRES_PASSWORD: sage
      POSTGRES_DB: sage
    ports:
      - 5432:5432
    networks:
      - weaver

  service:
    container_name: sage
    hostname: sage
    build:
      dockerfile: Dockerfile
      context: './'
      args:
        - NPM_REGISTRY=${NPM_REGISTRY}
        - NODE_ENV=${NODE_ENV}
    image: ${IMAGE_HOST}/${SERVICE_PROJECT}${SERVICE_PATH}:${IMAGE_VERSION}
    ports:
      - 9000:9000
    env_file:
      - .env
    networks:
      - weaver
    depends_on:
      - db

```