### PR TITLE
Issue 401: Cloning modals unresponsive after validation error.

### DIFF
--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -353,11 +353,14 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
 
     $scope.discoveryView.dirty(true);
 
-    if($scope.discoveryView.id) {
+    if ($scope.discoveryView.id) {
+      var originalId = $scope.discoveryView.id;
       delete $scope.discoveryView.id;
       DiscoveryViewRepo.create($scope.discoveryView).then(function(res) {
         if (angular.fromJson(res.body).meta.status === "SUCCESS") {
           $scope.cancelCloneDiscoveryView();
+        } else {
+          $scope.discoveryView.id = originalId;
         }
       });
     }

--- a/src/main/webapp/app/controllers/management/readerManagementController.js
+++ b/src/main/webapp/app/controllers/management/readerManagementController.js
@@ -112,11 +112,14 @@ sage.controller('ReaderManagementController', function ($controller, $scope, $ti
     $scope.cloningReader = true;
     applyFields($scope.readerToClone);
     $scope.readerToClone.dirty(true);
-    if($scope.readerToClone.id) {
+    if ($scope.readerToClone.id) {
+      var originalId = $scope.readerToClone.id;
       delete $scope.readerToClone.id;
       ReaderRepo.create($scope.readerToClone).then(function(res) {
         if (angular.fromJson(res.body).meta.status === "SUCCESS") {
           $scope.cancelCloneReader();
+        } else {
+          $scope.readerToClone.id = originalId;
         }
       });
     }

--- a/src/main/webapp/app/controllers/management/writerManagementController.js
+++ b/src/main/webapp/app/controllers/management/writerManagementController.js
@@ -109,11 +109,14 @@ sage.controller('WriterManagementController', function ($controller, $scope, NgT
     $scope.cloningWriter = true;
     applyMappings($scope.writerToClone);
     $scope.writerToClone.dirty(true);
-    if($scope.writerToClone.id) {
+    if ($scope.writerToClone.id) {
+      var originalId = $scope.writerToClone.id;
       delete $scope.writerToClone.id;
       WriterRepo.create($scope.writerToClone).then(function(res) {
       if (angular.fromJson(res.body).meta.status === "SUCCESS") {
         $scope.cancelCloneWriter();
+      } else {
+        $scope.writerToClone.id = originalId;
       }
     });
     }


### PR DESCRIPTION
# Description

The problem is that the id is removed from the form before submitting. This is done to trigger the generation of a new ID automatically on the backend. If the validation fails, the form no longer has the ID.

Fix this by saving the ID and restoring the ID to the form if clone submit did not succeed.

This same exact problematic logic is in the `ReaderManagementController` and the `WriterManagementController`. Given the identical scope, the same fix is applied to each of those as well.

Fixes #401

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual testing using maven, postgresql, and solr local instances.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

