### PR TITLE
Issue 476: Sort order toggle button appends value=undefined to URL, breaking the search.

### DIFF
--- a/src/main/webapp/app/controllers/discoveryContextController.js
+++ b/src/main/webapp/app/controllers/discoveryContextController.js
@@ -22,6 +22,9 @@ sage.controller('DiscoveryContextController', function ($controller, $scope, $ro
 
   $scope.discoveryContext.ready().then(function() {
 
+    // Prevent search value from being initially set as the string 'undefined'.
+    $scope.currentSearchValue = "";
+
     $scope.getNarrowLogoClass = function() {
       return {'background-image': 'url(' + $scope.discoveryContext.logoUrl + ')'};
     };


### PR DESCRIPTION
# Description

There are several areas where the is undefined logic can be improved. Fixing these does not solve the problem and such changes have been omitted.

The problem is that the form has an initial value that is undefined. When the form gets submitted, via a search button click or a sort button click, then the undefined gets translated into the string 'undefined'.

The immediate solution is to always initialize the value as an empty string before processing any of the URL arguments on first load.

Fixes #476

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Locally running.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

