### PR TITLE
Issue 475: Alphabetic follow up, addressing more management fields.

### DIFF
--- a/src/main/java/edu/tamu/sage/controller/IternalMetadataController.java
+++ b/src/main/java/edu/tamu/sage/controller/IternalMetadataController.java
@@ -5,6 +5,11 @@ import static edu.tamu.weaver.validation.model.BusinessValidationType.CREATE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 
+import edu.tamu.sage.model.InternalMetadata;
+import edu.tamu.sage.model.repo.InternalMetadataRepo;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,12 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import edu.tamu.sage.model.InternalMetadata;
-import edu.tamu.sage.model.repo.InternalMetadataRepo;
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 
 @RestController
 @RequestMapping("/internal/metadata")
@@ -34,7 +33,7 @@ public class IternalMetadataController {
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse getAll() {
-        return new ApiResponse(SUCCESS, internalMetadataRepo.findAll());
+        return new ApiResponse(SUCCESS, internalMetadataRepo.findAllByOrderByFieldAsc());
     }
 
     @PostMapping

--- a/src/main/java/edu/tamu/sage/controller/OperatorController.java
+++ b/src/main/java/edu/tamu/sage/controller/OperatorController.java
@@ -53,6 +53,11 @@ public class OperatorController {
         for (Type type : jsonSubTypes.value()) {
             types.add(new OperatorType(type.name(), type.value().getSimpleName()));
         }
+
+        types.sort((e1, e2) -> {
+          return e1.getName().compareTo(e2.getName());
+        });
+
         return new ApiResponse(SUCCESS, types);
     }
 

--- a/src/main/java/edu/tamu/sage/model/repo/InternalMetadataRepo.java
+++ b/src/main/java/edu/tamu/sage/model/repo/InternalMetadataRepo.java
@@ -3,7 +3,9 @@ package edu.tamu.sage.model.repo;
 import edu.tamu.sage.model.InternalMetadata;
 import edu.tamu.sage.model.repo.custom.InternalMetadataRepoCustom;
 import edu.tamu.weaver.data.model.repo.WeaverRepo;
+import java.util.List;
 
 public interface InternalMetadataRepo extends WeaverRepo<InternalMetadata>, InternalMetadataRepoCustom {
 
+  public List<InternalMetadata> findAllByOrderByFieldAsc();
 }

--- a/src/main/webapp/app/views/modals/cloneReaderModal.html
+++ b/src/main/webapp/app/views/modals/cloneReaderModal.html
@@ -49,7 +49,7 @@
           <ul class="list-group">
             <li class="list-group-item" ng-repeat="metadatum in internalMetadata | orderBy: 'id'">
               <label>{{metadatum.gloss}}</label>
-              <input class="form-control" type="text" name="fieldMapping" ng-model="readerFields[metadatum.field].value" uib-typeahead="f.name for f in fields | filter:$viewValue" />
+              <input class="form-control" type="text" name="fieldMapping" ng-model="readerFields[metadatum.field].value" uib-typeahead="f.name for f in fields | orderBy:'name' | filter:$viewValue" />
               <small ng-if="metadatum.required" class="form-text text-muted">This field is required.</small>
             </li>
           </ul>

--- a/src/main/webapp/app/views/modals/createReaderModal.html
+++ b/src/main/webapp/app/views/modals/createReaderModal.html
@@ -52,7 +52,7 @@
         <ul class="list-group">
           <li class="list-group-item" ng-repeat="metadatum in internalMetadata | orderBy: 'id'">
             <label>{{metadatum.gloss}}</label>
-            <input class="form-control" type="text" name="fieldMapping" ng-model="readerFields[metadatum.field].value" uib-typeahead="f.name for f in fields | filter:$viewValue" />
+            <input class="form-control" type="text" name="fieldMapping" ng-model="readerFields[metadatum.field].value" uib-typeahead="f.name for f in fields | orderBy:'name' | filter:$viewValue" />
             <small ng-if="metadatum.required" class="form-text text-muted">This field is required.</small>
           </li>
         </ul>

--- a/src/main/webapp/app/views/modals/updateReaderModal.html
+++ b/src/main/webapp/app/views/modals/updateReaderModal.html
@@ -50,7 +50,7 @@
         <ul class="list-group">
           <li class="list-group-item" ng-repeat="metadatum in internalMetadata | orderBy: 'id'">
             <label>{{metadatum.gloss}}</label>
-            <input class="form-control" type="text" name="fieldMapping" ng-model="readerFields[metadatum.field].value" uib-typeahead="f.name for f in fields | filter:$viewValue" />
+            <input class="form-control" type="text" name="fieldMapping" ng-model="readerFields[metadatum.field].value" uib-typeahead="f.name for f in fields | orderBy:'name' | filter:$viewValue" />
             <small ng-if="metadatum.required" class="form-text text-muted">This field is required.</small>
           </li>
         </ul>


### PR DESCRIPTION
# Description

There are additional management fields that are not alphabetically sorted that were missed in the previous PR (#486).

There are two cases where I opted to perform the sorting on the back-end.
The metadaum and operators.
On the UI side, both of these are either `validatedinput` or `multi-suggestion-input` fields.
I do not see any obvious support in weaver-ui-core that supports the sorting on the list.
Therefore, I opted to sort on the back-end.
I used the DB order for InternalMetadata.
I used the Java array string sort for the Operator given the current design.

The type aheads on the Readers have the UI orderBy filter added.
The Reader Field Mappings could also have additional sorting, but this requires more discussion and is omitted.

Fixes #475

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

