### PR TITLE
Enable support for multiple SOLR cores via Docker build arguments.

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,14 +1,23 @@
 FROM solr:7.7.2-slim
 
-RUN precreate-core sage-discovery
+ARG SOLR_USER="solr"
+ARG MAIN_CORE="sage-discovery"
+ARG EXTRA_CORES=""
 
-RUN chmod -R ugo+w /opt/solr/server/solr/
-RUN chmod -R ugo+w /opt/solr/server/logs/
+RUN precreate-core $MAIN_CORE
 
-COPY config /opt/solr/server/solr/mycores/sage-discovery/conf
+COPY config /opt/solr/server/solr/mycores/${MAIN_CORE}/conf
 
 USER root
 
-RUN chown -R solr:solr /opt/solr/server/solr/mycores/
+RUN if [ "$EXTRA_CORES" != "" ] ; then \
+      for core in $EXTRA_CORES ; do \
+        precreate-core $core && \
+        cp -R /opt/solr/server/solr/mycores/${MAIN_CORE}/conf /opt/solr/server/solr/mycores/${core}/ || exit 1 ; \
+      done \
+    fi
 
-USER solr
+RUN chown -R $SOLR_USER:$SOLR_USER /opt/solr/server/solr/mycores/
+RUN chmod -R ugo+w /opt/solr/server/solr /opt/solr/server/logs/
+
+USER $SOLR_USER


### PR DESCRIPTION
# Description

Adding additional cores for development and testing should be easier. The goal here is to make this easier by utilizing docker arguments.

The solr user is also abstracted into an argument for possible arg-based changes, if ever.

The default core is abstracted into `MAIN_CORE` docker build argument, with a default of `sage-discovery`. The additional cores are abstracted into `EXTRA_CORES` docker build argument. This is done primarily because docker has very poor (non-existent) loop and conditional handling. The `COPY` command needs to be performed in a loop or in conditions but such support is unavailable.

This takes the approach of checking if `EXTRA_CORES` is empty and if not loop over space separated core names. The `MAIN_CORE` must be pre-created so that the configuration can be copied. The copying of the configuration in this way avoids needing to use `COPY` and instead uses the system `cp` command.

The loops can continue on even in error so `&&`, `||`, and `exit 1` are used to guarantee that the loop fails on any error.

The two chmod commands are merged into a single command.

Example docker build usage:
```
docker build --build-arg=EXTRA_CORES="extra1 extra2" -t local_solr .
docker run -p 8983:8983 -it local_solr
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

