### PR TITLE
Issue 502: Angularjs $location.search is not safe to use when passing '#'.

### DIFF
--- a/src/main/webapp/app/model/discoveryContextModel.js
+++ b/src/main/webapp/app/model/discoveryContextModel.js
@@ -64,11 +64,12 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, Field, Man
 
     discoveryContext.before(function () {
       var filters = [];
+      var pattern = /#/;
 
       angular.forEach($routeParams, function(value, key) {
         if (key.match(/^f\./i)) {
           var filter = {
-            key: key.replace(/^f\./, ""),
+            key: key.replace(/^f\./, "").replace(pattern, "%23"),
             value: value
           };
           filters.push(filter);
@@ -76,8 +77,8 @@ sage.model("DiscoveryContext", function ($q, $location, $routeParams, Field, Man
       });
 
       discoveryContext.search = new Search({
-        field: angular.isDefined($routeParams.field) ? $routeParams.field : "",
-        value: angular.isDefined($routeParams.value) ? $routeParams.value : "",
+        field: angular.isDefined($routeParams.field) ? $routeParams.field.replace(pattern, "%23") : "",
+        value: angular.isDefined($routeParams.value) ? $routeParams.value.replace(pattern, "%23") : "",
         label: "",
         filters: filters,
         start: 0,


### PR DESCRIPTION
# Description

This is the solution created while investigating the spike #492.

This addresses the problem by replacing the `#` (U+0023) character with `%23` for relevant situations (properties in the search).

This needs to be tested for regressions, specifically checking for data in facets and filters that have the `#` (U+0023) character.

Fixes #502

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual
- [X] Front-end and Back-end tests run via `mvn clean test`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes