### PR TITLE
Clear values upon closing is resolved using angular.copy().

### DIFF
--- a/src/main/webapp/app/controllers/management/internalMetadataManagementController.js
+++ b/src/main/webapp/app/controllers/management/internalMetadataManagementController.js
@@ -57,7 +57,7 @@ sage.controller('InternalMetadataManagementController', function ($controller, $
   };
 
   $scope.startUpdateInternalMetadatum = function(internalMetadatum) {
-    $scope.internalMetadatumToUpdate = internalMetadatum;
+    $scope.internalMetadatumToUpdate = angular.copy(internalMetadatum);
     $scope.openModal("#updateInternalMetadatumModal");
   };
 

--- a/src/main/webapp/app/controllers/management/operatorManagementController.js
+++ b/src/main/webapp/app/controllers/management/operatorManagementController.js
@@ -113,7 +113,7 @@ sage.controller('OperatorManagementController', function ($controller, $scope, N
   };
 
   $scope.startUpdateOperator = function(operator) {
-    $scope.operatorToUpdate = operator;
+    $scope.operatorToUpdate = angular.copy(operator);
     $scope.typeChanged($scope.operatorToUpdate);
     $scope.openModal("#updateOperatorModal");
   };

--- a/src/main/webapp/app/controllers/management/readerManagementController.js
+++ b/src/main/webapp/app/controllers/management/readerManagementController.js
@@ -95,7 +95,7 @@ sage.controller('ReaderManagementController', function ($controller, $scope, $ti
   var readerToUpdateWatcher;
 
   $scope.startUpdateReader = function(reader) {
-    $scope.readerToUpdate = reader;
+    $scope.readerToUpdate = angular.copy(reader);
     if (readerToUpdateWatcher !== undefined) {
       readerToUpdateWatcher();
     }

--- a/src/main/webapp/app/controllers/management/sourceManagementController.js
+++ b/src/main/webapp/app/controllers/management/sourceManagementController.js
@@ -48,6 +48,7 @@ sage.controller('SourceManagementController', function ($controller, $scope, NgT
 
   $scope.updateSource = function() {
     $scope.updatingSource = true;
+    $scope.sourceToUpdate.dirty(true);
     $scope.sourceToUpdate.save().then(function() {
       $scope.resetSourceForms();
       $scope.updatingSource = false;

--- a/src/main/webapp/app/controllers/management/sourceManagementController.js
+++ b/src/main/webapp/app/controllers/management/sourceManagementController.js
@@ -55,7 +55,7 @@ sage.controller('SourceManagementController', function ($controller, $scope, NgT
   };
 
   $scope.startUpdateSource = function(core) {
-    $scope.sourceToUpdate = core;
+    $scope.sourceToUpdate = angular.copy(core);
     $scope.openModal("#updateSourceModal");
   };
 

--- a/src/main/webapp/app/controllers/management/writerManagementController.js
+++ b/src/main/webapp/app/controllers/management/writerManagementController.js
@@ -74,7 +74,7 @@ sage.controller('WriterManagementController', function ($controller, $scope, NgT
   };
 
   $scope.startUpdateWriter = function(writer) {
-    $scope.writerToUpdate = writer;
+    $scope.writerToUpdate = angular.copy(writer);
     angular.forEach($scope.writerToUpdate.outputMappings, function(mapping) {
       $scope.writerMappings[mapping.inputField] = mapping.mappings.join(";");
     });

--- a/src/main/webapp/tests/unit/controllers/management/internalMetadataManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/internalMetadataManagementControllerTest.js
@@ -227,7 +227,8 @@ describe("controller: InternalMetadataManagementController", function () {
 
       $scope.startUpdateInternalMetadatum(dataInternalMetadata1);
 
-      expect($scope.internalMetadatumToUpdate).toEqual(dataInternalMetadata1);
+      expect($scope.internalMetadatumToUpdate).toBeDefined();
+      expect($scope.internalMetadatumToUpdate.id).toEqual(dataInternalMetadata1.id)
       expect($scope.openModal).toHaveBeenCalled();
     });
 

--- a/src/main/webapp/tests/unit/controllers/management/jobManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/jobManagementControllerTest.js
@@ -317,7 +317,8 @@ describe("controller: JobManagementController", function () {
 
       $scope.startUpdateJob(job);
 
-      expect($scope.jobToUpdate.id).toEqual(job.id);
+      expect($scope.jobToUpdate).toBeDefined();
+      expect($scope.jobToUpdate.id).toEqual(job.id)
       expect($scope.openModal).toHaveBeenCalled();
     });
 

--- a/src/main/webapp/tests/unit/controllers/management/operatorManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/operatorManagementControllerTest.js
@@ -239,7 +239,8 @@ describe("controller: OperatorManagementController", function () {
 
       $scope.startUpdateOperator(operator);
 
-      expect($scope.operatorToUpdate).toEqual(operator);
+      expect($scope.operatorToUpdate).toBeDefined();
+      expect($scope.operatorToUpdate.id).toEqual(operator.id);
       expect($scope.openModal).toHaveBeenCalled();
     });
 

--- a/src/main/webapp/tests/unit/controllers/management/readerManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/readerManagementControllerTest.js
@@ -263,7 +263,8 @@ describe("controller: ReaderManagementController", function () {
 
       $scope.startUpdateReader(reader);
 
-      expect($scope.readerToUpdate).toEqual(reader);
+      expect($scope.readerToUpdate).toBeDefined();
+      expect($scope.readerToUpdate.id).toEqual(reader.id)
       expect($scope.openModal).toHaveBeenCalled();
     });
 

--- a/src/main/webapp/tests/unit/controllers/management/sourceManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/sourceManagementControllerTest.js
@@ -242,7 +242,8 @@ describe("controller: SourceManagementController", function () {
 
       $scope.startUpdateSource(source);
 
-      expect($scope.sourceToUpdate).toEqual(source);
+      expect($scope.sourceToUpdate).toBeDefined();
+      expect($scope.sourceToUpdate.id).toEqual(source.id)
       expect($scope.openModal).toHaveBeenCalled();
     });
 

--- a/src/main/webapp/tests/unit/controllers/management/writerManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/management/writerManagementControllerTest.js
@@ -285,7 +285,8 @@ describe("controller: WriterManagementController", function () {
 
       $scope.startUpdateWriter(writer);
 
-      expect($scope.writerToUpdate).toEqual(writer);
+      expect($scope.writerToUpdate).toBeDefined();
+      expect($scope.writerToUpdate.id).toEqual(writer.id)
       expect($scope.openModal).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
# Description
It uses the original values which is shared in the modal, which is not desirable. Upon clicking the `X` or the `Cancel` button, the original model value is updated, so utilized the copy() to resolve this behavior.

Fixes #480

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Visual Inspection
- [X] mvn clean test was successful


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

