### PR TITLE
Issue 519: Fix Bold Match Filter returning an empty bold markup.

### DIFF
--- a/src/main/webapp/app/filters/boldMatchFilter.js
+++ b/src/main/webapp/app/filters/boldMatchFilter.js
@@ -1,5 +1,11 @@
 sage.filter('boldMatch', function() {
   return function(input, match) {
-    return input.replace(match, "<b>" + match + "</b>");
+    if (angular.isDefined(input)) {
+      if (angular.isDefined(match) && angular.isString(match) && match.length > 0) {
+        return input.replace(match, "<b>" + match + "</b>");
+      }
+    }
+
+    return "";
   };
 });

--- a/src/main/webapp/tests/unit/filters/boldMatchFilterTest.js
+++ b/src/main/webapp/tests/unit/filters/boldMatchFilterTest.js
@@ -50,8 +50,7 @@ describe("filter: boldMatch", function () {
 
       result = filter("", "");
 
-      // fixme: the test should return an empty string not "<b></b>", the filter needs to be fixed!
-      //expect(result).toBe("");
+      expect(result).toBe("");
     });
 
     it("add bold tag on match", function () {


### PR DESCRIPTION
# Description

The bold match filter should not bold empty text but does.
The unit test has to comment out code and effectively be disabled due to this.

Fixes #519

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes