### PR TITLE
Issue 498: Always set facet min count to 1.

### DIFF
--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -126,6 +126,7 @@ public class SolrDiscoveryService {
 
             solrQuery.setFacet(true);
             solrQuery.setFacetLimit(Integer.MAX_VALUE);
+            solrQuery.setFacetMinCount(1);
         }
 
         search.setFilters(filters);


### PR DESCRIPTION
# Description

This ensures matches of 0 never appear in the facets. The SolrQuery class provides a handy `setFacetMinCount()` method to easily utilize this functionality.

Fixes #498

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

