### PR TITLE
Issue 515: Redesign Solr search process, particularly the Solr Core.

### DIFF
--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -102,18 +102,8 @@
 
   <!-- "facet" = provides a facet in its near original form for utilizing in searches.  -->
   <fieldType name="facet" class="solr.TextField" positionIncrementGap="100">
-    <analyzer type="index">
-      <tokenizer class="solr.StandardTokenizerFactory" />
-
-      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-      <filter class="solr.FlattenGraphFilterFactory" />
-    </analyzer>
-
-    <analyzer type="query">
-      <tokenizer class="solr.StandardTokenizerFactory" />
-
-      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-      <filter class="solr.CommonGramsQueryFilterFactory" />
+    <analyzer>
+      <tokenizer class="solr.KeywordTokenizerFactory" />
     </analyzer>
   </fieldType>
 

--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -99,6 +99,7 @@
 
   <!-- Copy all fields ending in '_t' into the all text search field. -->
   <copyField source="*_t" dest="_text_" />
+  <copyField source="*_t" dest="_text_ws" />
 
   <!-- "facet" = provides a facet in its near original form for utilizing in searches.  -->
   <fieldType name="facet" class="solr.TextField" positionIncrementGap="100">

--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -80,7 +80,7 @@
   <dynamicField name="*_whole_si" type="whole" indexed="true" stored="true" multiValued="false" />
   <dynamicField name="*_whole_si_t" type="whole" indexed="true" stored="true" multiValued="false" />
 
-  <!-- Special / Core fields. -->
+  <!-- Special / Core field types. -->
   <fieldType name="binary" class="solr.BinaryField" />
   <fieldType name="bool" class="solr.BoolField" sortMissingLast="true" />
   <fieldType name="date" class="solr.DatePointField" docValues="true" />

--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -1,1066 +1,304 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
-<!--
-
- This example schema is the recommended starting point for users.
- It should be kept correct and concise, usable out-of-the-box.
-
-
- For more information, on how to customize this file, please see
- http://lucene.apache.org/solr/guide/documents-fields-and-schema-design.html
-
- PERFORMANCE NOTE: this schema includes many optional features and should not
- be used for benchmarking.  To improve performance one could
-  - set stored="false" for all fields possible (esp large fields) when you
-    only need to search on the field but don't need to return the original
-    value.
-  - set indexed="false" if you don't need to search on the field, but only
-    return the field as a result of searching on other indexed fields.
-  - remove all unneeded copyField statements
-  - for best index size and searching performance, set "index" to false
-    for all general text fields, use copyField to copy them to the
-    catchall "text" field, and use that for searching.
--->
-
-<schema name="default-config" version="1.6">
-    <!-- attribute "name" is the name of this schema and is only used for display purposes.
-       version="x.y" is Solr's version number for the schema syntax and 
-       semantics.  It should not normally be changed by applications.
-
-       1.0: multiValued attribute did not exist, all fields are multiValued 
-            by nature
-       1.1: multiValued attribute introduced, false by default 
-       1.2: omitTermFreqAndPositions attribute introduced, true by default 
-            except for text fields.
-       1.3: removed optional field compress feature
-       1.4: autoGeneratePhraseQueries attribute introduced to drive QueryParser
-            behavior when a single string produces multiple tokens.  Defaults 
-            to off for version >= 1.4
-       1.5: omitNorms defaults to true for primitive field types 
-            (int, float, boolean, string...)
-       1.6: useDocValuesAsStored defaults to true.
-    -->
-
-    <!-- Valid attributes for fields:
-     name: mandatory - the name for the field
-     type: mandatory - the name of a field type from the 
-       fieldTypes section
-     indexed: true if this field should be indexed (searchable or sortable)
-     stored: true if this field should be retrievable
-     docValues: true if this field should have doc values. Doc Values is
-       recommended (required, if you are using *Point fields) for faceting,
-       grouping, sorting and function queries. Doc Values will make the index
-       faster to load, more NRT-friendly and more memory-efficient. 
-       They are currently only supported by StrField, UUIDField, all 
-       *PointFields, and depending on the field type, they might require
-       the field to be single-valued, be required or have a default value
-       (check the documentation of the field type you're interested in for
-       more information)
-     multiValued: true if this field may contain multiple values per document
-     omitNorms: (expert) set to true to omit the norms associated with
-       this field (this disables length normalization and index-time
-       boosting for the field, and saves some memory).  Only full-text
-       fields or fields that need an index-time boost need norms.
-       Norms are omitted for primitive (non-analyzed) types by default.
-     termVectors: [false] set to true to store the term vector for a
-       given field.
-       When using MoreLikeThis, fields used for similarity should be
-       stored for best performance.
-     termPositions: Store position information with the term vector.  
-       This will increase storage costs.
-     termOffsets: Store offset information with the term vector. This 
-       will increase storage costs.
-     required: The field is required.  It will throw an error if the
-       value does not exist
-     default: a value that should be used if no value is specified
-       when adding a document.
-    -->
-
-    <!-- field names should consist of alphanumeric or underscore characters only and
-      not start with a digit.  This is not currently strictly enforced,
-      but other field names will not have first class support from all components
-      and back compatibility is not guaranteed.  Names with both leading and
-      trailing underscores (e.g. _version_) are reserved.
-    -->
-
-    <!-- In this _default configset, only four fields are pre-declared:
-         id, _version_, and _text_ and _root_. All other fields will be type guessed and added via the
-         "add-unknown-fields-to-the-schema" update request processor chain declared in solrconfig.xml.
-         
-         Note that many dynamic fields are also defined - you can use them to specify a 
-         field's type via field naming conventions - see below.
-  
-         WARNING: The _text_ catch-all field will significantly increase your index size.
-         If you don't need it, consider removing it and the corresponding copyField directive.
-    -->
-
-    <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
-    <!-- docValues are enabled by default for long type so we don't need to index the version field  -->
-    <field name="_version_" type="plong" indexed="false" stored="false"/>
-    <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
-    <field name="_text_" type="text_general" indexed="true" stored="false" multiValued="true"/>
-    <field name="timestamp" type="pdate" indexed="true" stored="true" default="NOW" multiValued="false"/>
-
-
-    <!-- Internal -->
-    <field name="collection" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-    <field name="thumbnail" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="resource" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="manifest" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="application_type" type="whole_string" indexed="true" stored="true" multiValued="false"/>
-
-    <!-- Mandatory (M) -->
-    <field name="title" type="sorting_string" indexed="true" stored="true" multiValued="false"/>
-    <field name="content_type" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="digital_publisher" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="rights_access" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="reformatting" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="filename" type="sorting_string" indexed="true" stored="true" multiValued="true"/>
-
-    <copyField source="title" dest="_text_"/>
-    <copyField source="title" dest="title_txt_en_split"/>
-    <copyField source="digital_publisher" dest="_text_"/>
-
-    <!-- Mandatory if applicable and available (MA) -->
-    <field name="subject" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="creator" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="date_published" type="pdate" indexed="true" stored="true" multiValued="false"/>
-    <!--<field name="date_created" type="pdate" indexed="true" stored="true" multiValued="false"/>-->
-    <field name="date_created" type="whole_string" indexed="true" stored="true" multiValued="false"/>
-    <field name="summary_abstract" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="language" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="institution_department" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="standard_digital_identifier" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="local_digital_identifier" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="edition_revision_information" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-
-    <copyField source="subject" dest="_text_"/>
-    <copyField source="creator" dest="_text_"/>
-    <copyField source="summary_abstract" dest="_text_"/>
-    <copyField source="institution_department" dest="_text_"/>
-    <copyField source="edition_revision_information" dest="_text_"/>
-    <copyField source="summary_abstract" dest="summary_abstract_txt_en_split_mv"/>
-
-    <!-- Non-core Recommended -->
-    <field name="alternative_title" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="genre" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="table_of_contents" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="contributor" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="related_resource" type="strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="original_publisher" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="physical_extent" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="sponsor" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="details" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="spatial" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-
-    <copyField source="alternative_title" dest="_text_"/>
-    <copyField source="genre" dest="_text_"/>
-    <copyField source="contributor" dest="_text_"/>
-    <copyField source="original_publisher" dest="_text_"/>
-    <copyField source="sponsor" dest="_text_"/>
-    <copyField source="details" dest="_text_"/>
-    <copyField source="spatial" dest="_text_"/>
-
-    <!-- Non-core Optional -->
-    <field name="source_collection" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="original_resource" type="strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="notes" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="origin" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="audience_level" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="classification" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="physical_item_identifier" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-    <field name="physical_item_location" type="whole_strings" indexed="true" stored="true" multiValued="true"/>
-
-    <copyField source="notes" dest="_text_"/>
-    <copyField source="classification" dest="_text_"/>
-    <copyField source="notes" dest="notes_txt_en_split"/>
-
-
-    <!-- This can be enabled, in case the client does not know what fields may be searched. It isn't enabled by default
-         because it's very expensive to index everything twice. -->
-    <!-- <copyField source="*" dest="_text_"/> -->
-
-    <!-- Dynamic field definitions allow using convention over configuration
-       for fields via the specification of patterns to match field names.
-       EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
-       RESTRICTION: the glob-like pattern in the name attribute must have a "*" only at the start or the end.  -->
-
-    <!-- Field to use to determine and enforce document uniqueness.
-      Unless this field is marked with required="false", it will be a required field
-    -->
-    <uniqueKey>id</uniqueKey>
-
-    <!-- copyField commands copy one field to another at the time a document
-       is added to the index.  It's used either to index the same field differently,
-       or to add multiple fields to the same field for easier/faster searching.
-
-    <copyField source="sourceFieldName" dest="destinationFieldName"/>
-    -->
-
-    <!-- field type definitions. The "name" attribute is
-       just a label to be used by field definitions.  The "class"
-       attribute and any other attributes determine the real
-       behavior of the fieldType.
-         Class names starting with "solr" refer to java classes in a
-       standard package such as org.apache.solr.analysis
-    -->
-
-    <!-- sortMissingLast and sortMissingFirst attributes are optional attributes are
-         currently supported on types that are sorted internally as strings
-         and on numeric types.
-       This includes "string", "boolean", "pint", "pfloat", "plong", "pdate", "pdouble".
-       - If sortMissingLast="true", then a sort on this field will cause documents
-         without the field to come after documents with the field,
-         regardless of the requested sort order (asc or desc).
-       - If sortMissingFirst="true", then a sort on this field will cause documents
-         without the field to come before documents with the field,
-         regardless of the requested sort order.
-       - If sortMissingLast="false" and sortMissingFirst="false" (the default),
-         then default lucene sorting will be used which places docs without the
-         field first in an ascending sort and last in a descending sort.
-    -->
-
-    <!-- sorting string type  -->
-    <fieldType name="sorting_string" class="solr.TextField" omitNorms="true" sortMissingLast="true">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!--
-      An alternative to string type that is utilizes a lower case filter.
-      The solr.StrField does not allow this.
-      Base types like solr.StrField have omitNorms="true" by default.
-      This sets omitNorms="true" to more closely match the solr.StrField type.
-      The docValues="true" from solrStrField cannot be preserved because solr.TextField does not support it.
-    -->
-    <fieldType name="whole_string" class="solr.TextField" omitNorms="true" sortMissingLast="true">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    <fieldType name="whole_strings" class="solr.TextField" omitNorms="true" sortMissingLast="true" multiValued="true">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
-    <fieldType name="strings" class="solr.StrField" sortMissingLast="true" multiValued="true" docValues="true" />
-
-    <!-- boolean type: "true" or "false" -->
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
-    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
-
-    <!--
-      Numeric field types that index values using KD-trees.
-      Point fields don't support FieldCache, so they must have docValues="true" if needed for sorting, faceting, functions, etc.
-    -->
-    <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
-    <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>
-    <fieldType name="plong" class="solr.LongPointField" docValues="true"/>
-    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
-    
-    <fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
-    <fieldType name="pfloats" class="solr.FloatPointField" docValues="true" multiValued="true"/>
-    <fieldType name="plongs" class="solr.LongPointField" docValues="true" multiValued="true"/>
-    <fieldType name="pdoubles" class="solr.DoublePointField" docValues="true" multiValued="true"/>
-    <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
-
-
-    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
-         is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime 
-         The trailing "Z" designates UTC time and is mandatory.
-         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
-         All other components are mandatory.
-
-         Expressions can also be used to denote calculations that should be
-         performed relative to "NOW" to determine the value, ie...
-
-               NOW/HOUR
-                  ... Round to the start of the current hour
-               NOW-1DAY
-                  ... Exactly 1 day prior to now
-               NOW/DAY+6MONTHS+3DAYS
-                  ... 6 months and 3 days in the future from the start of
-                      the current day
-                      
-      -->
-    <!-- KD-tree versions of date fields -->
-    <fieldType name="pdate" class="solr.DatePointField" docValues="true"/>
-    <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true"/>
-
-    <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
-    <fieldType name="binary" class="solr.BinaryField"/>
-
-    <!-- solr.TextField allows the specification of custom text analyzers
-         specified as a tokenizer and a list of token filters. Different
-         analyzers may be specified for indexing and querying.
-
-         The optional positionIncrementGap puts space between multiple fields of
-         this type on the same document, with the purpose of preventing false phrase
-         matching across fields.
-
-         For more info on customizing your analyzer chain, please see
-         http://lucene.apache.org/solr/guide/understanding-analyzers-tokenizers-and-filters.html#understanding-analyzers-tokenizers-and-filters
-     -->
-
-    <!-- One can also specify an existing Analyzer class that has a
-         default constructor via the class attribute on the analyzer element.
-         Example:
-    <fieldType name="text_greek" class="solr.TextField">
-      <analyzer class="org.apache.lucene.analysis.el.GreekAnalyzer"/>
-    </fieldType>
-    -->
-
-    <!-- A text field that only splits on whitespace for exact matching of words -->
-    <dynamicField name="*_ws" type="text_ws"  indexed="true"  stored="true"/>
-    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- A general text field that has reasonable, generic
-         cross-language defaults: it tokenizes with StandardTokenizer,
-	       removes stop words from case-insensitive "stopwords.txt"
-	       (empty by default), and down cases.  At query time only, it
-	       also applies synonyms.
-	  -->
-    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100" multiValued="true">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.FlattenGraphFilterFactory"/>
-        -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1"/>
-        <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <!-- <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/> -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    
-    <!-- SortableTextField generaly functions exactly like TextField,
-         except that it supports, and by default uses, docValues for sorting (or faceting)
-         on the first 1024 characters of the original field values (which is configurable).
-         
-         This makes it a bit more useful then TextField in many situations, but the trade-off
-         is that it takes up more space on disk; which is why it's not used in place of TextField
-         for every fieldType in this _default schema.
-	  -->
-    <dynamicField name="*_t_sort" type="text_gen_sort" indexed="true" stored="true" multiValued="false"/>
-    <dynamicField name="*_txt_sort" type="text_gen_sort" indexed="true" stored="true"/>
-    <fieldType name="text_gen_sort" class="solr.SortableTextField" positionIncrementGap="100" multiValued="true">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- A text field with defaults appropriate for English: it tokenizes with StandardTokenizer,
-         removes English stop words (lang/stopwords_en.txt), down cases, protects words from protwords.txt, and
-         finally applies Porter's stemming.  The query time analyzer also applies synonyms from synonyms.txt. -->
-    <dynamicField name="*_txt_en" type="text_en"  indexed="true"  stored="true"/>
-    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.FlattenGraphFilterFactory"/>
-        -->
-        <!-- Case insensitive stop word removal. -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-	      -->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-	      -->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- A text field with defaults appropriate for English, plus
-         aggressive word-splitting and autophrase features enabled.
-         This field is just like text_en, except it adds
-         WordDelimiterGraphFilter to enable splitting and matching of
-         words on case-change, alpha numeric boundaries, and
-         non-alphanumeric chars.  This means certain compound word
-         cases will work, for example query "wi fi" will match
-         document "WiFi" or "wi-fi".
-    -->
-    <dynamicField name="*_txt_en_split" type="text_en_splitting"  indexed="true"  stored="true"/>
-    <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal. -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <dynamicField name="*_txt_en_split_mv" type="text_en_splitting"  indexed="true" stored="true" multiValued="true"/>
-
-    <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
-         but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->
-    <dynamicField name="*_txt_en_split_tight" type="text_en_splitting_tight"  indexed="true"  stored="true"/>
-    <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterGraphFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Just like text_general except it reverses the characters of
-	       each token, to enable more efficient leading wildcard queries.
-    -->
-    <dynamicField name="*_txt_rev" type="text_general_rev"  indexed="true"  stored="true"/>
-    <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
-                maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <dynamicField name="*_phon_en" type="phonetic_en"  indexed="true"  stored="true"/>
-    <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- lowercases the entire field value, keeping it as a single token.  -->
-    <dynamicField name="*_s_lower" type="lowercase"  indexed="true"  stored="true"/>
-    <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!-- 
-      Example of using PathHierarchyTokenizerFactory at index time, so
-      queries for paths match documents at that path, or in descendent paths
-    -->
-    <dynamicField name="*_descendent_path" type="descendent_path"  indexed="true"  stored="true"/>
-    <fieldType name="descendent_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!--
-      Example of using PathHierarchyTokenizerFactory at query time, so
-      queries for paths match documents at that path, or in ancestor paths
-    -->
-    <dynamicField name="*_ancestor_path" type="ancestor_path"  indexed="true"  stored="true"/>
-    <fieldType name="ancestor_path" class="solr.TextField">
-      <analyzer type="index">
-        <tokenizer class="solr.KeywordTokenizerFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
-      </analyzer>
-    </fieldType>
-
-    <!-- This point type indexes the coordinates as separate fields (subFields)
-      If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
-      subFieldSuffix is defined, that is used to create the subFields.
-      Example: if subFieldType="double", then the coordinates would be
-        indexed in fields myloc_0___double,myloc_1___double.
-      Example: if subFieldSuffix="_d" then the coordinates would be indexed
-        in fields myloc_0_d,myloc_1_d
-      The subFields are an implementation detail of the fieldType, and end
-      users normally should not need to know about them.
-     -->
-    <dynamicField name="*_point" type="point"  indexed="true"  stored="true"/>
-    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-
-    <!-- A specialized field for geospatial search filters and distance sorting. -->
-    <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
-
-    <!-- A geospatial field type that supports multiValued and polygon shapes.
-      For more information about this and other spatial fields see:
-      http://lucene.apache.org/solr/guide/spatial-search.html
-    -->
-    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
-               geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers" />
-
-    <!-- Payloaded field types -->
-    <fieldType name="delimited_payloads_float" stored="false" indexed="true" class="solr.TextField">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
-      </analyzer>
-    </fieldType>
-    <fieldType name="delimited_payloads_int" stored="false" indexed="true" class="solr.TextField">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="integer"/>
-      </analyzer>
-    </fieldType>
-    <fieldType name="delimited_payloads_string" stored="false" indexed="true" class="solr.TextField">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="identity"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- some examples for different languages (generally ordered by ISO code) -->
-
-    <!-- Arabic -->
-    <dynamicField name="*_txt_ar" type="text_ar"  indexed="true"  stored="true"/>
-    <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- for any non-arabic -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ar.txt" />
-        <!-- normalizes ﻯ to ﻱ, etc -->
-        <filter class="solr.ArabicNormalizationFilterFactory"/>
-        <filter class="solr.ArabicStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Bulgarian -->
-    <dynamicField name="*_txt_bg" type="text_bg"  indexed="true"  stored="true"/>
-    <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/> 
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" /> 
-        <filter class="solr.BulgarianStemFilterFactory"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- Catalan -->
-    <dynamicField name="*_txt_ca" type="text_ca"  indexed="true"  stored="true"/>
-    <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
-    <dynamicField name="*_txt_cjk" type="text_cjk"  indexed="true"  stored="true"/>
-    <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- normalize width before bigram, as e.g. half-width dakuten combine  -->
-        <filter class="solr.CJKWidthFilterFactory"/>
-        <!-- for any non-CJK -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.CJKBigramFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Czech -->
-    <dynamicField name="*_txt_cz" type="text_cz"  indexed="true"  stored="true"/>
-    <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
-        <filter class="solr.CzechStemFilterFactory"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- Danish -->
-    <dynamicField name="*_txt_da" type="text_da"  indexed="true"  stored="true"/>
-    <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>       
-      </analyzer>
-    </fieldType>
-    
-    <!-- German -->
-    <dynamicField name="*_txt_de" type="text_de"  indexed="true"  stored="true"/>
-    <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
-        <filter class="solr.GermanNormalizationFilterFactory"/>
-        <filter class="solr.GermanLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.GermanMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Greek -->
-    <dynamicField name="*_txt_el" type="text_el"  indexed="true"  stored="true"/>
-    <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- greek specific lowercase for sigma -->
-        <filter class="solr.GreekLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_el.txt" />
-        <filter class="solr.GreekStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Spanish -->
-    <dynamicField name="*_txt_es" type="text_es"  indexed="true"  stored="true"/>
-    <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
-        <filter class="solr.SpanishLightStemFilterFactory"/>
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Basque -->
-    <dynamicField name="*_txt_eu" type="text_eu"  indexed="true"  stored="true"/>
-    <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Persian -->
-    <dynamicField name="*_txt_fa" type="text_fa"  indexed="true"  stored="true"/>
-    <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <!-- for ZWNJ -->
-        <charFilter class="solr.PersianCharFilterFactory"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ArabicNormalizationFilterFactory"/>
-        <filter class="solr.PersianNormalizationFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
-      </analyzer>
-    </fieldType>
-    
-    <!-- Finnish -->
-    <dynamicField name="*_txt_fi" type="text_fi"  indexed="true"  stored="true"/>
-    <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Finnish"/>
-        <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- French -->
-    <dynamicField name="*_txt_fr" type="text_fr"  indexed="true"  stored="true"/>
-    <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" />
-        <filter class="solr.FrenchLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Irish -->
-    <dynamicField name="*_txt_ga" type="text_ga"  indexed="true"  stored="true"/>
-    <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes d', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
-        <!-- removes n-, etc. position increments is intentionally false! -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/hyphenations_ga.txt"/>
-        <filter class="solr.IrishLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ga.txt"/>
-        <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Galician -->
-    <dynamicField name="*_txt_gl" type="text_gl"  indexed="true"  stored="true"/>
-    <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
-        <filter class="solr.GalicianStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Hindi -->
-    <dynamicField name="*_txt_hi" type="text_hi"  indexed="true"  stored="true"/>
-    <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <!-- normalizes unicode representation -->
-        <filter class="solr.IndicNormalizationFilterFactory"/>
-        <!-- normalizes variation in spelling -->
-        <filter class="solr.HindiNormalizationFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hi.txt" />
-        <filter class="solr.HindiStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Hungarian -->
-    <dynamicField name="*_txt_hu" type="text_hu"  indexed="true"  stored="true"/>
-    <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
-        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->   
-      </analyzer>
-    </fieldType>
-    
-    <!-- Armenian -->
-    <dynamicField name="*_txt_hy" type="text_hy"  indexed="true"  stored="true"/>
-    <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Indonesian -->
-    <dynamicField name="*_txt_id" type="text_id"  indexed="true"  stored="true"/>
-    <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
-        <!-- for a less aggressive approach (only inflectional suffixes), set stemDerivational to false -->
-        <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Italian -->
-  <dynamicField name="*_txt_it" type="text_it"  indexed="true"  stored="true"/>
-  <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- removes l', etc -->
-        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_it.txt" format="snowball" />
-        <filter class="solr.ItalianLightStemFilterFactory"/>
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
-
-         NOTE: If you want to optimize search for precision, use default operator AND in your request
-         handler config (q.op) Use OR if you would like to optimize for recall (default).
-    -->
-    <dynamicField name="*_txt_ja" type="text_ja"  indexed="true"  stored="true"/>
-    <fieldType name="text_ja" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="false">
-      <analyzer>
-        <!-- Kuromoji Japanese morphological analyzer/tokenizer (JapaneseTokenizer)
-
-           Kuromoji has a search mode (default) that does segmentation useful for search.  A heuristic
-           is used to segment compounds into its parts and the compound itself is kept as synonym.
-
-           Valid values for attribute mode are:
-              normal: regular segmentation
-              search: segmentation useful for search with synonyms compounds (default)
-            extended: same as search mode, but unigrams unknown words (experimental)
-
-           For some applications it might be good to use search mode for indexing and normal mode for
-           queries to reduce recall and prevent parts of compounds from being matched and highlighted.
-           Use <analyzer type="index"> and <analyzer type="query"> for this and mode normal in query.
-
-           Kuromoji also has a convenient user dictionary feature that allows overriding the statistical
-           model with your own entries for segmentation, part-of-speech tags and readings without a need
-           to specify weights.  Notice that user dictionaries have not been subject to extensive testing.
-
-           User dictionary attributes are:
-                     userDictionary: user dictionary filename
-             userDictionaryEncoding: user dictionary encoding (default is UTF-8)
-
-           See lang/userdict_ja.txt for a sample user dictionary file.
-
-           Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
-        -->
-        <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
-        <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
-        <!-- Reduces inflected verbs and adjectives to their base/dictionary forms (辞書形) -->
-        <filter class="solr.JapaneseBaseFormFilterFactory"/>
-        <!-- Removes tokens with certain part-of-speech tags -->
-        <filter class="solr.JapanesePartOfSpeechStopFilterFactory" tags="lang/stoptags_ja.txt" />
-        <!-- Normalizes full-width romaji to half-width and half-width kana to full-width (Unicode NFKC subset) -->
-        <filter class="solr.CJKWidthFilterFactory"/>
-        <!-- Removes common tokens typically not useful for search, but have a negative effect on ranking -->
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ja.txt" />
-        <!-- Normalizes common katakana spelling variations by removing any last long sound character (U+30FC) -->
-        <filter class="solr.JapaneseKatakanaStemFilterFactory" minimumLength="4"/>
-        <!-- Lower-cases romaji characters -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Korean morphological analysis -->
-    <dynamicField name="*_txt_ko" type="text_ko"  indexed="true"  stored="true"/>
-    <fieldType name="text_ko" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <!-- Nori Korean morphological analyzer/tokenizer (KoreanTokenizer)
-          The Korean (nori) analyzer integrates Lucene nori analysis module into Solr.
-          It uses the mecab-ko-dic dictionary to perform morphological analysis of Korean texts.
-
-          This dictionary was built with MeCab, it defines a format for the features adapted
-          for the Korean language.
-          
-          Nori also has a convenient user dictionary feature that allows overriding the statistical
-          model with your own entries for segmentation, part-of-speech tags and readings without a need
-          to specify weights. Notice that user dictionaries have not been subject to extensive testing.
-
-          The tokenizer supports multiple schema attributes:
-            * userDictionary: User dictionary path.
-            * userDictionaryEncoding: User dictionary encoding.
-            * decompoundMode: Decompound mode. Either 'none', 'discard', 'mixed'. Default is 'discard'.
-            * outputUnknownUnigrams: If true outputs unigrams for unknown words.
-        -->
-        <tokenizer class="solr.KoreanTokenizerFactory" decompoundMode="discard" outputUnknownUnigrams="false"/>
-        <!-- Removes some part of speech stuff like EOMI (Pos.E), you can add a parameter 'tags',
-          listing the tags to remove. By default it removes: 
-          E, IC, J, MAG, MAJ, MM, SP, SSC, SSO, SC, SE, XPN, XSA, XSN, XSV, UNA, NA, VSV
-          This is basically an equivalent to stemming.
-        -->
-        <filter class="solr.KoreanPartOfSpeechStopFilterFactory" />
-        <!-- Replaces term text with the Hangul transcription of Hanja characters, if applicable: -->
-        <filter class="solr.KoreanReadingFormFilterFactory" />
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-    </fieldType>
-
-    <!-- Latvian -->
-    <dynamicField name="*_txt_lv" type="text_lv"  indexed="true"  stored="true"/>
-    <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
-        <filter class="solr.LatvianStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Dutch -->
-    <dynamicField name="*_txt_nl" type="text_nl"  indexed="true"  stored="true"/>
-    <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
-        <filter class="solr.StemmerOverrideFilterFactory" dictionary="lang/stemdict_nl.txt" ignoreCase="false"/>
-        <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Norwegian -->
-    <dynamicField name="*_txt_no" type="text_no"  indexed="true"  stored="true"/>
-    <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Norwegian"/>
-        <!-- less aggressive: <filter class="solr.NorwegianLightStemFilterFactory"/> -->
-        <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Portuguese -->
-  <dynamicField name="*_txt_pt" type="text_pt"  indexed="true"  stored="true"/>
-  <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
-        <filter class="solr.PortugueseLightStemFilterFactory"/>
-        <!-- less aggressive: <filter class="solr.PortugueseMinimalStemFilterFactory"/> -->
-        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Portuguese"/> -->
-        <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Romanian -->
-    <dynamicField name="*_txt_ro" type="text_ro"  indexed="true"  stored="true"/>
-    <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
-      </analyzer>
-    </fieldType>
-    
-    <!-- Russian -->
-    <dynamicField name="*_txt_ru" type="text_ru"  indexed="true"  stored="true"/>
-    <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Russian"/>
-        <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Swedish -->
-    <dynamicField name="*_txt_sv" type="text_sv"  indexed="true"  stored="true"/>
-    <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Swedish"/>
-        <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
-      </analyzer>
-    </fieldType>
-    
-    <!-- Thai -->
-    <dynamicField name="*_txt_th" type="text_th"  indexed="true"  stored="true"/>
-    <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.ThaiTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
-      </analyzer>
-    </fieldType>
-    
-    <!-- Turkish -->
-    <dynamicField name="*_txt_tr" type="text_tr"  indexed="true"  stored="true"/>
-    <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.TurkishLowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Similarity is the scoring routine for each document vs. a query.
-       A custom Similarity or SimilarityFactory may be specified here, but 
-       the default is fine for most applications.  
-       For more info: http://lucene.apache.org/solr/guide/other-schema-elements.html#OtherSchemaElements-Similarity
-    -->
-    <!--
-     <similarity class="com.example.solr.CustomSimilarityFactory">
-       <str name="paramkey">param value</str>
-     </similarity>
-    -->
 
+<schema name="sage-config" version="1.0">
+
+  <uniqueKey>id</uniqueKey>
+
+  <!-- Core Fields -->
+  <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
+  <field name="_version_" type="long" indexed="false" stored="false" multiValued="false" />
+  <field name="_root_" type="string" indexed="true" stored="false" docValues="false" />
+  <field name="_text_" type="text" />
+  <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false" />
+
+  <!-- '_si' = single, '_t' = copy to '_text_' -->
+  <dynamicField name="*_binary" type="binary" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_binary_t" type="binary" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_binary_si" type="binary" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_binary_si_t" type="binary" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_bool" type="bool" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_bool_t" type="bool" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_bool_si" type="bool" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_bool_si_t" type="bool" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_date_t" type="date" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_date_si" type="date" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_date_si_t" type="date" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_double" type="double" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_double_t" type="double" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_double_si" type="double" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_double_si_t" type="double" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_facet" type="facet" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_facet_si" type="facet" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_float" type="float" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_float_t" type="float" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_float_si" type="float" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_float_si_t" type="float" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_int" type="int" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_int_t" type="int" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_int_si" type="int" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_int_si_t" type="int" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_long" type="long" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_long_t" type="long" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_long_si" type="long" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_long_si_t" type="long" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_random" type="random" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_random_t" type="random" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_random_si" type="random" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_random_si_t" type="random" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_string" type="string" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_string_t" type="string" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_string_si" type="string" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_string_si_t" type="string" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_text" type="text" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_text_t" type="text" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_text_si" type="text" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_text_si_t" type="text" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_text_en_split" type="text_en_split"  indexed="true"  stored="true" />
+  <dynamicField name="*_text_en_split_t" type="text_en_split"  indexed="true"  stored="true" />
+  <dynamicField name="*_text_si_en_split" type="text_en_split"  indexed="true"  stored="true" multiValued="false" />
+  <dynamicField name="*_text_si_en_split_t" type="text_en_split"  indexed="true"  stored="true" multiValued="false" />
+
+  <dynamicField name="*_ws" type="text_ws" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_ws_t" type="text_ws" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_ws_si" type="text_ws" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_ws_si_t" type="text_ws" indexed="true" stored="true" multiValued="false" />
+
+  <dynamicField name="*_whole" type="whole" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_whole_t" type="whole" indexed="true" stored="true" multiValued="true" />
+  <dynamicField name="*_whole_si" type="whole" indexed="true" stored="true" multiValued="false" />
+  <dynamicField name="*_whole_si_t" type="whole" indexed="true" stored="true" multiValued="false" />
+
+  <!-- Special / Core fields. -->
+  <fieldType name="binary" class="solr.BinaryField" />
+  <fieldType name="bool" class="solr.BoolField" sortMissingLast="true" />
+  <fieldType name="date" class="solr.DatePointField" docValues="true" />
+  <fieldType name="double" class="solr.DoublePointField" docValues="true" />
+  <fieldType name="float" class="solr.FloatPointField" docValues="true" />
+  <fieldType name="int" class="solr.IntPointField" docValues="true" />
+  <fieldType name="long" class="solr.LongPointField" docValues="true" />
+  <fieldType name="random" class="solr.RandomSortField" indexed="true" />
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
+
+  <!-- Special Multi-valued used in solrconfig.xml -->
+  <fieldType name="dates" class="solr.DatePointField" docValues="true" multiValued="true" />
+  <fieldType name="bools" class="solr.BoolField" sortMissingLast="true" multiValued="true" />
+  <fieldType name="longs" class="solr.LongPointField" docValues="true" multiValued="true" />
+  <fieldType name="doubles" class="solr.DoublePointField" docValues="true" multiValued="true" />
+
+  <!-- Copy all fields ending in '_t' into the all text search field. -->
+  <copyField source="*_t" dest="_text_" />
+
+  <!-- "facet" = provides a facet in its near original form for utilizing in searches.  -->
+  <fieldType name="facet" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory" />
+
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+      <filter class="solr.FlattenGraphFilterFactory" />
+    </analyzer>
+
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory" />
+
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+      <filter class="solr.CommonGramsQueryFilterFactory" />
+    </analyzer>
+  </fieldType>
+
+  <!-- "text" = normal text (separates spaces on query)  -->
+  <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory" />
+
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" />
+      <filter class="solr.FlattenGraphFilterFactory" />
+      <filter class="solr.LowerCaseFilterFactory" />
+    </analyzer>
+
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+      <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="solr.CommonGramsQueryFilterFactory" />
+    </analyzer>
+  </fieldType>
+
+  <!-- "text_ws" = normal text using whitespace tokenization (separates spaces on query)  -->
+  <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+      <filter class="solr.LowerCaseFilterFactory" />
+    </analyzer>
+
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+      <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="solr.CommonGramsQueryFilterFactory" />
+    </analyzer>
+  </fieldType>
+
+  <!-- A language-specific text field with aggressive word-splitting and autophrase features enabled. -->
+  <fieldType name="text_en_split" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+    <analyzer type="index">
+      <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
+      <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="solr.EnglishMinimalStemFilterFactory" />
+      <filter class="solr.EnglishPossessiveFilterFactory" />
+      <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
+      <filter class="solr.PorterStemFilterFactory" />
+      <filter class="solr.FlattenGraphFilterFactory" />
+    </analyzer>
+
+    <analyzer type="query">
+      <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true" />
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
+      <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="solr.EnglishMinimalStemFilterFactory" />
+      <filter class="solr.EnglishPossessiveFilterFactory" />
+      <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
+      <filter class="solr.PorterStemFilterFactory" />
+      <filter class="solr.CommonGramsQueryFilterFactory" />
+    </analyzer>
+  </fieldType>
+
+  <!-- "whole" = whole string (does not separate spaces on query) -->
+  <fieldType name="whole" class="solr.TextField" omitNorms="true" sortMissingLast="true">
+    <analyzer type="index">
+      <tokenizer class="solr.KeywordTokenizerFactory" />
+    </analyzer>
+
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory" />
+
+      <filter class="solr.LowerCaseFilterFactory" />
+    </analyzer>
+  </fieldType>
+
+  <!-- Everything below is added for compatibility with older style, remove these when no longer needed. -->
+
+  <!-- Internal -->
+  <field name="collection" type="whole" indexed="true" stored="true" multiValued="false" required="true" />
+  <field name="thumbnail" type="whole" indexed="true" stored="true" multiValued="false" />
+  <field name="resource" type="whole" indexed="true" stored="true" multiValued="false" />
+  <field name="manifest" type="whole" indexed="true" stored="true" multiValued="false" />
+  <field name="application_type" type="text" indexed="true" stored="true" multiValued="false" />
+
+  <copyField source="application_type" dest="application_type_facet" />
+
+  <!-- Mandatory (M) -->
+  <field name="title" type="text" indexed="true" stored="true" multiValued="false" />
+  <field name="content_type" type="text" indexed="true" stored="true" />
+  <field name="digital_publisher" type="text" indexed="true" stored="true" />
+  <field name="rights_access" type="text" indexed="true" stored="true" />
+  <field name="reformatting" type="text" indexed="true" stored="true" />
+  <field name="filename" type="whole" indexed="true" stored="true" />
+
+  <copyField source="title" dest="_text_" />
+  <copyField source="title" dest="_text_ws" />
+  <copyField source="title" dest="title_text_si_en_split" />
+  <copyField source="title" dest="title_facet" />
+  <copyField source="content_type" dest="content_type_facet" />
+  <copyField source="digital_publisher" dest="_text_" />
+  <copyField source="digital_publisher" dest="_text_ws" />
+  <copyField source="digital_publisher" dest="digital_publisher_facet" />
+
+  <!-- Mandatory if applicable and available (MA) -->
+  <field name="subject" type="text" indexed="true" stored="true" />
+  <field name="creator" type="text" indexed="true" stored="true" />
+  <field name="date_published" type="date" indexed="true" stored="true" multiValued="false" />
+  <field name="date_created" type="date" indexed="true" stored="true" multiValued="false" />
+  <field name="summary_abstract" type="text" indexed="true" stored="true" />
+  <field name="language" type="text" indexed="true" stored="true" />
+  <field name="institution_department" type="text" indexed="true" stored="true" />
+  <field name="standard_digital_identifier" type="text" indexed="true" stored="true" />
+  <field name="local_digital_identifier" type="text" indexed="true" stored="true" />
+  <field name="edition_revision_information" type="text" indexed="true" stored="true" />
+
+  <copyField source="subject" dest="_text_" />
+  <copyField source="subject" dest="_text_ws" />
+  <copyField source="subject" dest="subject_facet" />
+  <copyField source="subject" dest="subject_ws" />
+  <copyField source="creator" dest="_text_" />
+  <copyField source="creator" dest="_text_ws" />
+  <copyField source="creator" dest="creator_facet" />
+  <copyField source="summary_abstract" dest="_text_" />
+  <copyField source="summary_abstract" dest="_text_ws" />
+  <copyField source="summary_abstract" dest="summary_abstract_facet" />
+  <copyField source="summary_abstract" dest="summary_abstract_text_en_split" />
+  <copyField source="institution_department" dest="_text_" />
+  <copyField source="institution_department" dest="_text_ws" />
+  <copyField source="institution_department" dest="institution_department_facet" />
+
+  <!-- Non-core Recommended -->
+  <field name="alternative_title" type="text" indexed="true" stored="true" />
+  <field name="genre" type="text" indexed="true" stored="true" />
+  <field name="table_of_contents" type="text" indexed="true" stored="true" />
+  <field name="contributor" type="text" indexed="true" stored="true" />
+  <field name="related_resource" type="text" indexed="true" stored="true" />
+  <field name="original_publisher" type="text" indexed="true" stored="true" />
+  <field name="physical_extent" type="text" indexed="true" stored="true" />
+  <field name="sponsor" type="text" indexed="true" stored="true" />
+  <field name="details" type="text" indexed="true" stored="true" />
+  <field name="spatial" type="text" indexed="true" stored="true" />
+
+  <copyField source="alternative_title" dest="_text_" />
+  <copyField source="alternative_title" dest="_text_ws" />
+  <copyField source="alternative_title" dest="alternative_title_facet" />
+  <copyField source="genre" dest="_text_" />
+  <copyField source="genre" dest="_text_ws" />
+  <copyField source="genre" dest="genre_facet" />
+  <copyField source="contributor" dest="_text_" />
+  <copyField source="contributor" dest="_text_ws" />
+  <copyField source="contributor" dest="contributor_facet" />
+  <copyField source="original_publisher" dest="_text_" />
+  <copyField source="original_publisher" dest="_text_ws" />
+  <copyField source="original_publisher" dest="original_publisher_facet" />
+  <copyField source="sponsor" dest="_text_" />
+  <copyField source="sponsor" dest="_text_ws" />
+  <copyField source="sponsor" dest="sponsor_facet" />
+  <copyField source="details" dest="_text_" />
+  <copyField source="details" dest="_text_ws" />
+  <copyField source="details" dest="details_facet" />
+  <copyField source="spatial" dest="_text_" />
+  <copyField source="spatial" dest="_text_ws" />
+  <copyField source="spatial" dest="spatial_facet" />
+
+  <!-- Non-core Optional -->
+  <field name="source_collection" type="text" indexed="true" stored="true" />
+  <field name="original_resource" type="text" indexed="true" stored="true" />
+  <field name="notes" type="text" indexed="true" stored="true" />
+  <field name="origin" type="text" indexed="true" stored="true" />
+  <field name="audience_level" type="text" indexed="true" stored="true" />
+  <field name="classification" type="text" indexed="true" stored="true" />
+  <field name="physical_item_identifier" type="text" indexed="true" stored="true" />
+  <field name="physical_item_location" type="text" indexed="true" stored="true" />
+
+  <copyField source="notes" dest="_text_" />
+  <copyField source="notes" dest="_text_ws" />
+  <copyField source="notes" dest="notes_facet" />
+  <copyField source="notes" dest="notes_text_en_split" />
+  <copyField source="classification" dest="_text_" />
+  <copyField source="classification" dest="_text_ws" />
+  <copyField source="classification" dest="classification_facet" />
 </schema>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -694,10 +694,10 @@
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
       <!-- Default search field
-         <str name="df">text</str> 
+         <str name="df">text</str>
         -->
       <!-- Change from JSON to XML format (the default prior to Solr 7.0)
-         <str name="wt">xml</str> 
+         <str name="wt">xml</str>
         -->
     </lst>
     <!-- In addition to defaults, "appends" params can be specified
@@ -852,7 +852,7 @@
     -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 
-    <str name="queryAnalyzerFieldType">text_general</str>
+    <str name="queryAnalyzerFieldType">text</str>
 
     <!-- Multiple "Spell Checkers" can be declared and used by this
          component
@@ -1119,7 +1119,7 @@
        Field type guessing update processors that will
        attempt to parse string-typed field values as Booleans, Longs,
        Doubles, or Dates, and then add schema fields with the guessed
-       field types. Text content will be indexed as "text_general" as
+       field types. Text content will be indexed as "text" as
        well as a copy to a plain string version in *_str.
 
        These require that the schema is both managed and mutable, by
@@ -1153,7 +1153,7 @@
       <str>yyyy-MM-dd'T'HH:mm:ssz</str>
       <str>yyyy-MM-dd'T'HH:mm:ssZ</str>
       <str>yyyy-MM-dd'T'HH:mm:ssZZ</str>
-      
+
       <str>yyyy-MM-dd'T'HH:mm</str>
       <str>yyyy-MM-dd'T'HH:mmz</str>
       <str>yyyy-MM-dd'T'HH:mmZ</str>
@@ -1163,17 +1163,17 @@
       <str>yyyy-MM-dd HH:mm:ss.SSSz</str>
       <str>yyyy-MM-dd HH:mm:ss.SSSZ</str>
       <str>yyyy-MM-dd HH:mm:ss.SSSZZ</str>
-      
+
       <str>yyyy-MM-dd HH:mm:ss,SSS</str>
       <str>yyyy-MM-dd HH:mm:ss,SSSz</str>
       <str>yyyy-MM-dd HH:mm:ss,SSSZ</str>
       <str>yyyy-MM-dd HH:mm:ss,SSSZZ</str>
-      
+
       <str>yyyy-MM-dd HH:mm:ss</str>
       <str>yyyy-MM-dd HH:mm:ssz</str>
       <str>yyyy-MM-dd HH:mm:ssZ</str>
       <str>yyyy-MM-dd HH:mm:ssZZ</str>
-      
+
       <str>yyyy-MM-dd HH:mm</str>
       <str>yyyy-MM-dd HH:mmz</str>
       <str>yyyy-MM-dd HH:mmZ</str>
@@ -1191,30 +1191,26 @@
   <updateProcessor class="solr.AddSchemaFieldsUpdateProcessorFactory" name="add-schema-fields">
     <lst name="typeMapping">
       <str name="valueClass">java.lang.String</str>
-      <str name="fieldType">text_general</str>
-      <lst name="copyField">
-        <str name="dest">*_str</str>
-        <int name="maxChars">256</int>
-      </lst>
+      <str name="fieldType">text</str>
       <!-- Use as default mapping instead of defaultFieldType -->
       <bool name="default">true</bool>
     </lst>
     <lst name="typeMapping">
       <str name="valueClass">java.lang.Boolean</str>
-      <str name="fieldType">booleans</str>
+      <str name="fieldType">bools</str>
     </lst>
     <lst name="typeMapping">
       <str name="valueClass">java.util.Date</str>
-      <str name="fieldType">pdates</str>
+      <str name="fieldType">dates</str>
     </lst>
     <lst name="typeMapping">
       <str name="valueClass">java.lang.Long</str>
       <str name="valueClass">java.lang.Integer</str>
-      <str name="fieldType">plongs</str>
+      <str name="fieldType">longs</str>
     </lst>
     <lst name="typeMapping">
       <str name="valueClass">java.lang.Number</str>
-      <str name="fieldType">pdoubles</str>
+      <str name="fieldType">doubles</str>
     </lst>
   </updateProcessor>
 

--- a/solr/config/stopwords.txt
+++ b/solr/config/stopwords.txt
@@ -12,3 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+and
+or
+of
+the
+but
+not

--- a/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
+++ b/src/main/java/edu/tamu/sage/controller/DiscoveryViewController.java
@@ -126,7 +126,7 @@ public class DiscoveryViewController {
 
         Map<String, String> filterMap = new HashMap<String,String>();
         reqFilterMap.forEach((k,v) -> {
-           filterMap.put( k.replace("f.", ""), v);
+           filterMap.put(k.replace("f.", ""), v);
         });
 
         return new ApiResponse(SUCCESS, solrDiscoveryService.buildDiscoveryContext(discoveryView, field, value, page, offset, filterMap));

--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -86,22 +86,16 @@ public class SolrDiscoveryService {
 
         String query = "";
         if (search.getField().isEmpty() && search.getValue().isEmpty()) {
-            query = "*:*";
+            query = "*";
         } else if (search.getField().isEmpty()) {
             query = search.getValue();
+        } else if (search.getValue().isEmpty()) {
+            query = search.getField() + ":*";
         } else {
             query = search.getField() + ":" + search.getValue();
         }
 
         SolrQuery solrQuery = new SolrQuery(query);
-
-        if (discoveryView.getFilter().isEmpty()) {
-            if (discoveryView.getSource().getRequiresFilter()) {
-                solrQuery.addFilterQuery(FILTER_WILDCARD);
-            }
-        } else {
-            solrQuery.addFilterQuery(discoveryView.getFilter());
-        }
 
         // Only filter against designated facet fields.
         List<Filter> filters = new ArrayList<Filter>();
@@ -111,8 +105,8 @@ public class SolrDiscoveryService {
 
                 String filterKey = facetField.getKey();
                 if (filterMap.containsKey(filterKey)) {
-                    String[] filterValues = filterMap.get(filterKey).split(","+FILTER_VALUE_PREFIX, -1);
-                    filterValues[0] = filterValues[0].replace(FILTER_VALUE_PREFIX,"");
+                    String[] filterValues = filterMap.get(filterKey).split("," + FILTER_VALUE_PREFIX, -1);
+                    filterValues[0] = filterValues[0].replace(FILTER_VALUE_PREFIX, "");
                     for (int i = 0; i < filterValues.length; i++) {
                         Filter filter = new Filter();
                         filter.setKey(facetField.getKey());
@@ -126,6 +120,14 @@ public class SolrDiscoveryService {
 
             solrQuery.setFacet(true);
             solrQuery.setFacetLimit(Integer.MAX_VALUE);
+        }
+
+        if (discoveryView.getFilter().isEmpty()) {
+            if (filters.isEmpty() && discoveryView.getSource().getRequiresFilter()) {
+                solrQuery.addFilterQuery(FILTER_WILDCARD);
+            }
+        } else {
+            solrQuery.addFilterQuery(discoveryView.getFilter());
         }
 
         search.setFilters(filters);
@@ -143,6 +145,9 @@ public class SolrDiscoveryService {
                 solrQuery.setParam("q.op", defaultOperand);
             }
         }
+
+        // Default "Separate On Whitespace" to true.
+        solrQuery.setParam("sow", "true");
 
         solrQuery.setRows(page.getPageSize());
         solrQuery.setStart((page.getPageNumber() * page.getPageSize()) + offset);


### PR DESCRIPTION
# Description

This commit represents the results of the investagtion described in issue #515.

There are several things to consider and this takes a compatible approach focusing on re-using as much of the existing design as possible. There is some inconvenience or cost for taking this approach.

The use of `df` (default field) is not implemented with these changes but is strongly recommended for future Sage releases. This does not update the documentation (such as the Github documentation). That documentation needs to be updated following this set of changes.

**Source Code Changes**

Change the default query from `*:*` to just `*`.
This restricts the searches to just the fields being searched rather than searching on everything. This can be further improved by providing a `df` (default field). When multiple fields are to be searched, then the `df` may not be a good idea.

Searching using a selected field now provides a wild card when the search field value is empty. This allows for default searches without values to work correctly.

The filter query and wild card is being improperly added when there are multiple filters. The wild card filter search query is (improperly) being added when there are specific search values specified. Change the logic to only add the wild card filter search query when there are no filters selected.

Always enable `sow` by default.
Ideally this should be a configurable option and future versions should allow for this to be configured. This is very important to have when passing strings. This may need to be turned off when intentionally adding quoted searches. This should be explicitly investigated for regressions. Additional logic can be added to dynamically disable this if quoted strings are passed but this behavioral change is outside the scope of this change set.

**Solr Core Changes**

We should be using the managed schema with dynamic fields. This allows for fine-tuning the behavior on an as-needed basis on read and/or write. Much of the needed functionality to do this is actually present by design. This is strong evidence to the good quality in the planning and the simplicity of the original Sage design. However, there are additional changes that can be made to polish this interface. Such changes are outside the scope of this change set and are left for future Sage releases.

This implementation is a complete rewrite from scratch of the previous design. It favors dynamic fields while simultaneously providing backwards and forwards compatibility fields.

Some of the Core Fields are preserved mostly as-is. Aside from the Core Fields, Sage should exclusively utilize non-base field types and instead use the custom dynamic fields. The use of simple names are chosen for each of the dynamic fields but future versions of Sage should review and provide a more thorough plan on the naming scheme. Unfortunately, Solr Core has design limitations that prevents this from operating in an ideal manner.

The dynamic fields have a now standardized sub-type naming scheme. The default behavior is now always multi-valued.
To have single valued type, the sub-type `_si` must be at the very end of the field name. To have the field get copied into the `_text_` field, commonly known as the "Everything" field, the sub-type `_t` must be at the very end of the field name. These two sub-types are the only combinable types for design simplicity and practicality reasons.

Due to a design limitation of Solr, complex regex combinations of say `_si` and `_t` cannot be used. To work-around this problem, all combinations have to be manually created. To avoid having to write all permutations, the order of specific sub-types are explicitly defined. The `_si` must come before `_t` and the `_t` must always be the last part (necessary for the copy field for `_t` to automatically work). For example, a single valued `title` field that is copied into `_text_` should be named `title_si_t`. This can be done by adding this a new metadatum.
Not all combinations are supported for practicality reasons (and some might not make sense when combined).

The most notable dynamic fields are:
- `*_text` (and its sub-types): All text fields and may have `_si` or `_t`.
- `*_string` (and its sub-types): A dynamic field compatible variation of the base `string` type and may have `_si` or `_t`.
- `*_ws` (and its sub-types): All text fields explicitly using the white-space splitting tokenizer and may have `_si` or `_t`.
- `*_facet` (and its sub-types): All text fields that are designed to be used during faceting and must not have `_si` or `_t`.
- `*_whole` (and its sub-types): All text fields being stored as a single field and the entire string must match, probably should never have `_si` or `_t`.

The original field schema structure is recreated utilizing these dynamic fields for compatibility reasons. Future versions of Sage ideally should not have most of these or should have none of these.

More complex "good to have" types such as URI are omitted. A URI type would be good to have because it would allow for partial matches against the URI (which could be a URN or a URL). For example searching for `tamu.edu` should match a full URL like `https://library.tamu.edu/`. At this time, these URI paths are using the `_whole` text type.

The research has revealed that searching using the white-space tokenizer results in more natural and more accurate searches. This is not well tested and there may be problems with this that are simply unknown due to my inexperience with the data and its intended daily or normal uses. The `_ws` Dynamic Field is available to provide control over switching between the standard and the white-space tokenizer algorithms by the Manager. This has a notable downside of adding even more fields to select from. This includes, perhaps, adding even more metadata.

Several of the problems with searching are solved by strongly separating the `index` and the `query` analyzers. Most of the time both the `index` and the `query` analyzers must be lower-case to match. This introduces a problem with the Faceting design provided by Sage. The tokenized results that are needed for both queries and indexes to operate in a proper or ideal manner interferes with the desired design of the faceting. The `_facet` Dynamic Field is added to address this problem. All facets should select the `_facet` Dynamic Field. This field is manually created using Copy Fields for compatibility reasons and to help avoid needing to create metadata for every single type to be faceted. This is an important design area that needs more design considerations for future Sage releases.

The `_en_split` text type is added to be compatible with the older Solr core designo. I do not know if this is needed and future development should consider the removal or further adoption of this.

Much of these changes create a strong desire to improve the Sage UI and UX to make handling all of the sub-types and Dynamic Fields more practical. Such changes are considered outside the scope of this issue and are ignored. This is another important area that needs more technical design planning.

The `solrconfig.xml` must be changed due to the re-write of the schema. The changes are kept to a bare minimum and are primarily focused around Field Name changes. The `_str` Copy Fields in the `solrconfig.xml` are entirely removed.

Basic stop words are added as an example.
This needs to be properly setup.
The `_facet` Dynamic Field utilizes these stop words. There may need to be more than one type, such as `stopwords-facet.txt` if the facets needs special handling beyond the normal stop words.

With this change, the system can have Dynamic Fields added through Sage itself. That means the Solr core does not need to be directly touched.

Be sure to rename `managed-schema` to `managed-schema.xml` when Solr Core gets updated to more recent versions.

Fixes #515

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually through SAGE's UI.
- [x] Manually directly through Solr.
- [x] Through unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes