### PR TITLE
Issue 515: Improve text_ws and whole_string query searching.

### DIFF
--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -132,21 +132,26 @@
     <analyzer type="index">
       <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false" />
       <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0" />
       <filter class="solr.LowerCaseFilterFactory" />
       <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
-      <filter class="solr.PorterStemFilterFactory" />
+      <filter class="solr.EnglishMinimalStemFilterFactory" />
+      <!-- <filter class="RemoveDuplicatesTokenFilterFactory" /> --> <!-- Not currently available. -->
       <filter class="solr.FlattenGraphFilterFactory" />
     </analyzer>
 
     <analyzer type="query">
       <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
+      <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false" />
       <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0" />
       <filter class="solr.LowerCaseFilterFactory" />
       <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
-      <filter class="solr.PorterStemFilterFactory" />
-      <filter class="solr.CommonGramsQueryFilterFactory" />
+      <filter class="solr.EnglishMinimalStemFilterFactory" />
+      <!-- <filter class="RemoveDuplicatesTokenFilterFactory" /> --> <!-- Not currently available. -->
     </analyzer>
   </fieldType>
 

--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -133,7 +133,6 @@
       <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
       <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
       <filter class="solr.LowerCaseFilterFactory" />
       <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
       <filter class="solr.PorterStemFilterFactory" />
@@ -144,7 +143,6 @@
       <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
       <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
       <filter class="solr.LowerCaseFilterFactory" />
       <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
       <filter class="solr.PorterStemFilterFactory" />

--- a/solr/config/managed-schema
+++ b/solr/config/managed-schema
@@ -128,17 +128,26 @@
   </fieldType>
 
   <!-- "text_ws" = normal text using whitespace tokenization (separates spaces on query)  -->
-  <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+  <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
     <analyzer type="index">
       <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
       <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
+      <filter class="solr.PorterStemFilterFactory" />
+      <filter class="solr.FlattenGraphFilterFactory" />
     </analyzer>
 
     <analyzer type="query">
       <tokenizer class="solr.WhitespaceTokenizerFactory" />
 
+      <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_en.txt" />
+      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
       <filter class="solr.LowerCaseFilterFactory" />
+      <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt" />
+      <filter class="solr.PorterStemFilterFactory" />
       <filter class="solr.CommonGramsQueryFilterFactory" />
     </analyzer>
   </fieldType>
@@ -181,8 +190,6 @@
 
     <analyzer type="query">
       <tokenizer class="solr.StandardTokenizerFactory" />
-
-      <filter class="solr.LowerCaseFilterFactory" />
     </analyzer>
   </fieldType>
 


### PR DESCRIPTION
# Description

The text_ws should use more of the properties off of the standardized string represented by the text_general field and text_en_split field.

The whole_string should not use the lower case filter.

This also automatically performs multilingual matching of sorts.
Searching for the English word "Reserved" for example may find German matches.

Attempts to use `solr.WordDelimiterGraphFilterFactory` (including with `preserveOriginal="1"`) have solved the immediate problem but introduced a regression where the quote strings never match anymore. This has graph has been removed from this change set.

Fixes #515

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually through the UI.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes