### PR TITLE
Default Field and wild cards don't work as expected.

### DIFF
--- a/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrDiscoveryService.java
@@ -84,7 +84,12 @@ public class SolrDiscoveryService {
             });
         }
 
-        SolrQuery solrQuery = new SolrQuery(StringUtils.isEmpty(search.getValue()) ? "*" : search.getValue());
+        String query = StringUtils.isEmpty(search.getValue()) ? "*" : search.getValue();
+        if (StringUtils.isNotEmpty(search.getField()) && StringUtils.isEmpty(search.getValue())) {
+          query = search.getField() + ":*";
+        }
+
+        SolrQuery solrQuery = new SolrQuery(query);
 
         if (StringUtils.isNotEmpty(search.getField())) {
           solrQuery.add("df", search.getField());


### PR DESCRIPTION
# Description

One would expect that when the default field is set to say `origin`, then the default wild card would be against the `origin`. This is not the case.

If there is no value but there is a search field, then prepend the search field before the wild card like `origin:*`.

The regressed behavior would result in an parsed query of:
```json
{
  "responseHeader":{
    "status":0,
    "QTime":0,
    "params":{
      "q":"*",
      "df":"origin",
      "debug":"query",
      "sow":"true",
      "rows":"0",
      "_":"1675954886742"}},
  "response":{"numFound":6494,"start":0,"docs":[]
  },
  "debug":{
    "rawquerystring":"*",
    "querystring":"*",
    "parsedquery":"MatchAllDocsQuery(*:*)",
    "parsedquery_toString":"*:*",
    "QParser":"LuceneQParser"
  }
}
```
Adding the default search of `origin` before the wild card results in:
```json
{
  "responseHeader":{
    "status":0,
    "QTime":0,
    "params":{
      "q":"origin:*",
      "df":"origin",
      "debug":"query",
      "sow":"true",
      "rows":"0",
      "_":"1675954886742"}},
  "response":{"numFound":724,"start":0,"docs":[]
  },
  "debug":{
    "rawquerystring":"origin:*",
    "querystring":"origin:*",
    "parsedquery":"origin:*",
    "parsedquery_toString":"origin:*",
    "QParser":"LuceneQParser"
  }
}
```

This is a regression discovered while testing out staging branch for the 2023, 2 SAGE sprint.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes