### PR TITLE
Regression in boldMatch filter causing autocomplete drop down to not work as expected.

### DIFF
--- a/src/main/webapp/app/components/multiSuggestionInputComponent.js
+++ b/src/main/webapp/app/components/multiSuggestionInputComponent.js
@@ -20,7 +20,7 @@ sage.component("multiSuggestionInput", {
 
     $scope.processKeyDown = function($event, filteredSuggestion) {
       switch($event.which) {
-        case 38: //Up Arrow 
+        case 38: //Up Arrow
           $event.preventDefault();
           break;
         case 40: //Down Arrow
@@ -35,7 +35,7 @@ sage.component("multiSuggestionInput", {
     };
 
     $scope.processKeyUp = function($event, filteredSuggestion) {
-      switch($event.which) {
+      switch ($event.which) {
         case 13: //Enter
           addValue(fs[$scope.selectedIndex][$ctrl.optionproperty]);
           $timeout(function() {
@@ -48,7 +48,7 @@ sage.component("multiSuggestionInput", {
           break;
         case 37: //Left Arrow
           if(shouldOpen()) {
-            openSuggestions(); 
+            openSuggestions();
           } else {
             closeSuggestions();
           }
@@ -60,7 +60,7 @@ sage.component("multiSuggestionInput", {
           break;
         case 39: //Right Arrow
           if(shouldOpen()) {
-            openSuggestions(); 
+            openSuggestions();
           } else {
             closeSuggestions();
           }
@@ -69,7 +69,7 @@ sage.component("multiSuggestionInput", {
         case 40: //Down Arrow
           $scope.selectedIndex = $scope.selectedIndex === filteredSuggestion.length - 1 ? 0: $scope.selectedIndex+1;
           $event.preventDefault();
-          break;  
+          break;
         default:
           typing($event);
       }
@@ -81,26 +81,26 @@ sage.component("multiSuggestionInput", {
     var typing = function($event) {
       var elem = $element.find(".input").get(0);
       var cursorPos = getCursorPosition();
-      
+
       var m = $scope.$ctrl.model[$scope.$ctrl.property];
 
       var nextChar = angular.copy(m.slice(cursorPos, cursorPos+1));
 
-      if($scope.open) {
+      if ($scope.open) {
         $scope.curentValue =  angular.copy(m.slice(curentValueStartPos, cursorPos));
         $scope.selectedIndex=0;
       } else {
         curentValueStartPos=cursorPos;
       }
 
-      if(shouldOpen()) {
+      if (shouldOpen()) {
         openSuggestions();
         if(nextChar!=="}") {
           addValue("}}", true);
           $timeout(function() {
             setCursor(elem,cursorPos);
           });
-        }  
+        }
       } else {
         $timeout(function() {
           closeSuggestions();
@@ -162,7 +162,7 @@ sage.component("multiSuggestionInput", {
     var setCursor = function(node,pos){
 
         node = (typeof node == "string" || node instanceof String) ? document.getElementById(node) : node;
-    
+
         if(!node){
             return false;
         }else if(node.createTextRange){
@@ -174,10 +174,10 @@ sage.component("multiSuggestionInput", {
             return true;
         } else if(node.setSelectionRange){
               node.setSelectionRange(pos,pos);
-            
+
             return true;
         }
-    
+
         return false;
     };
 

--- a/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
+++ b/src/main/webapp/app/controllers/management/discoveryViewManagementController.js
@@ -34,9 +34,9 @@ sage.controller('DiscoveryViewManagementController', function ($controller, $sco
     });
 
     return `${label}
-            ${$scope.discoveryViewForms.validations[labelAsKey] && 
-            $scope.discoveryViewForms.validations[labelAsKey].required ? 
-            '*': 
+            ${$scope.discoveryViewForms.validations[labelAsKey] &&
+            $scope.discoveryViewForms.validations[labelAsKey].required ?
+            '*':
             ''}`;
   };
 

--- a/src/main/webapp/app/filters/boldMatchFilter.js
+++ b/src/main/webapp/app/filters/boldMatchFilter.js
@@ -6,6 +6,6 @@ sage.filter('boldMatch', function() {
       }
     }
 
-    return "";
+    return input.replace(match, "");
   };
 });

--- a/src/main/webapp/app/filters/boldMatchFilter.js
+++ b/src/main/webapp/app/filters/boldMatchFilter.js
@@ -4,8 +4,10 @@ sage.filter('boldMatch', function() {
       if (angular.isDefined(match) && angular.isString(match) && match.length > 0) {
         return input.replace(match, "<b>" + match + "</b>");
       }
+
+      return input.replace(match, "");
     }
 
-    return input.replace(match, "");
+    return "";
   };
 });


### PR DESCRIPTION
# Description

The autocomplete drop down is requiring the input variable to be modified. The return value is not being processed at all.

When there is no matches, the input value must still be modified, even if the modification makes it empty.

While investigating this, a ton of white space ended up being auto-corrected. I decided to leave those corrections.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual
- [x] Unit Test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes