### PR TITLE
Fix regression in field spanning width with overly long text.

### DIFF
--- a/src/main/webapp/app/resources/styles/sass/components/result-entry.scss
+++ b/src/main/webapp/app/resources/styles/sass/components/result-entry.scss
@@ -13,6 +13,7 @@ result-entry {
     width: fit-content;
     margin-top: -19px;
     min-height: 28px;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
# Description

The commit 696e359c4709b8b1d3051b86f2b2900ee0ddc3bf introduced this regression. Text is not wrapping anymore.

As a quick fix, add a word break to the styling.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

