### PR TITLE
Work-around problem where upstream source deleted the npmjs registry for ng-openseadragon.

### DIFF
--- a/.wvr/build-config.js
+++ b/.wvr/build-config.js
@@ -59,7 +59,7 @@ const config = {
       './node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js',
       './node_modules/ng-table/bundles/ng-table.js',
       './node_modules/openseadragon/build/openseadragon/openseadragon.js',
-      './node_modules/ng-openseadragon/build/angular-openseadragon.js',
+      './node_modules/ng-openseadragon/dist/ng-openseadragon.min.js',
       './node_modules/tamu-mirador/dist/mirador.min.js',
       './node_modules/@wvr/core/app/config/coreConfig.js',
       './node_modules/@wvr/core/app/components/version/version.js',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@wvr/core": "2.2.2",
     "tamu-mirador": "3.3.1-rc.1",
     "ng-csv": "0.3.6",
-    "ng-openseadragon": "1.3.5",
+    "ng-openseadragon": "https://github.com/driannaude/ng-openseadragon.git#fa1a0faf005f2052aa2661e64df646c86c353ed3",
     "ng-table": "3.1.0",
     "openseadragon": "2.4.2",
     "react": "^16.13.1",


### PR DESCRIPTION
The upstream URL from the npg registry has been completely deleted and all packages there are lost.

Use the git repository directly.

Use a hash rather than a tag because tags can easily be deleted.
Hashes require more intentional effort.
This hash is currently the same commit pointed to by the `v1.3.5` tag.
