### PR TITLE
Improve handling of local Weaver-UI-Core repo, adding support for detecting the branch or tag name.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [ push, pull_request, workflow_dispatch ]
 
+env:
+  CI_WUI_BRANCH: ${{ vars.CI_WUI_BRANCH }}
+  CI_WUI_DISABLE_LOCAL_PUBLISH: ${{ vars.CI_WUI_DISABLE_LOCAL_PUBLISH }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,11 +22,32 @@ jobs:
           repository: TAMULib/Weaver-UI-Core
           path: weaver-ui
           ref: 2.x
+          # Specify depth of 0 to enable fetching all branches and tags so that the "Use Custom Weaver-UI-Core Repo Version" works.
+          fetch-depth: 0
+
+      - name: "Detect Custom Weaver-UI-Core Repo Version"
+        continue-on-error: true
+        if: ${{ env.CI_WUI_BRANCH == '' }}
+        run: |
+            cd weaver-ui
+            export CI_WUI_BRANCH_VERSION=$(grep -so -m 1 '"@wvr/core": "[^"]*"' ../repo/package.json | sed -e 's|"@wvr/core": "||' -e 's|"$||')
+            export CI_WUI_BRANCH=$(git tag | grep -so -m 1 "^$CI_WUI_BRANCH_VERSION$")
+            # Some projects prefix their version with a "v".
+            if [[ $CI_WUI_BRANCH == "" && $CI_WUI_BRANCH_VERSION != "" ]] ; then export CI_WUI_BRANCH=$(git tag | grep -so -m 1 "^v$CI_WUI_BRANCH_VERSION$") ; fi
+            echo "CI_WUI_BRANCH=$CI_WUI_BRANCH" >> $GITHUB_ENV
+
+      - name: "Use Custom Weaver-UI-Core Repo Version"
+        continue-on-error: true
+        if: ${{ env.CI_WUI_BRANCH != '' }}
+        run: |
+          cd weaver-ui
+          git reset --hard $CI_WUI_BRANCH
 
       - name: "Run Weaver-UI-Core Docker Compose Registry Image"
         run: docker-compose -f $GITHUB_WORKSPACE/weaver-ui/docker-compose.yml up -d registry
 
       - name: "Publish Weaver-UI-Core (@wvr/core)"
+        if: ${{ env.CI_WUI_DISABLE_LOCAL_PUBLISH != 'true' }}
         run: |
           cd $GITHUB_WORKSPACE/weaver-ui
           npm run publish:local


### PR DESCRIPTION
# Description

This adds two configuration variables:
1) `CI_WUI_BRANCH`
2) `CI_WUI_DISABLE_LOCAL_PUBLISH`

The `CI_WUI_BRANCH` should allow for a custom branch to be used in the local Verdaccio NPM hosting. The `CI_WUI_DISABLE_LOCAL_PUBLISH` should allow for disabling the local Verdaccio NPM hosting.

These should be configurable as per the following documentation:
- https://docs.github.com/en/actions/learn-github-actions/contexts#vars-context
- https://docs.github.com/en/actions/learn-github-actions/variables#defining-variables-for-multiple-workflows

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Github Actions run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

