### PR TITLE
The sage-1_0 should use "*_string" rather than "*_str", "string" rather than "whole", and other core related changes.

### DIFF
--- a/solr/configsets/sage-1_0/conf/managed-schema.xml
+++ b/solr/configsets/sage-1_0/conf/managed-schema.xml
@@ -205,6 +205,9 @@
   <field name="manifest" type="string" indexed="true" stored="true" multiValued="false" />
   <field name="application_type" type="text_general" indexed="true" stored="true" multiValued="false" />
 
+  <copyField source="collection" dest="collection_facet" />
+  <copyField source="thumbnail" dest="thumbnail_facet" />
+  <copyField source="resource" dest="resource_facet" />
   <copyField source="application_type" dest="application_type_facet" />
 
   <!-- Mandatory (M) -->
@@ -223,6 +226,8 @@
   <copyField source="digital_publisher" dest="_text_" />
   <copyField source="digital_publisher" dest="_text_ws" />
   <copyField source="digital_publisher" dest="digital_publisher_facet" />
+  <copyField source="reformatting" dest="reformatting_facet" />
+  <copyField source="filename" dest="filename_facet" />
 
   <!-- Mandatory if applicable and available (MA) -->
   <field name="subject" type="text_general" indexed="true" stored="true" multiValued="true" />
@@ -232,8 +237,8 @@
   <field name="summary_abstract" type="text_general" indexed="true" stored="true" multiValued="true" />
   <field name="language" type="text_general" indexed="true" stored="true" multiValued="true" />
   <field name="institution_department" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="standard_digital_identifier" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="local_digital_identifier" type="text_general" indexed="true" stored="true" multiValued="true" />
+  <field name="standard_digital_identifier" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="local_digital_identifier" type="string" indexed="true" stored="true" multiValued="true" />
   <field name="edition_revision_information" type="text_general" indexed="true" stored="true" multiValued="true" />
 
   <copyField source="subject" dest="_text_" />
@@ -243,13 +248,21 @@
   <copyField source="creator" dest="_text_" />
   <copyField source="creator" dest="_text_ws" />
   <copyField source="creator" dest="creator_facet" />
+  <copyField source="date_published" dest="date_published_facet" />
+  <copyField source="date_created" dest="date_created_facet" />
   <copyField source="summary_abstract" dest="_text_" />
   <copyField source="summary_abstract" dest="_text_ws" />
   <copyField source="summary_abstract" dest="summary_abstract_facet" />
   <copyField source="summary_abstract" dest="summary_abstract_text_en_split" />
+  <copyField source="language" dest="language_facet" />
   <copyField source="institution_department" dest="_text_" />
   <copyField source="institution_department" dest="_text_ws" />
   <copyField source="institution_department" dest="institution_department_facet" />
+  <copyField source="standard_digital_identifier" dest="standard_digital_identifier_text" />
+  <copyField source="standard_digital_identifier" dest="standard_digital_identifier_facet" />
+  <copyField source="local_digital_identifier" dest="local_digital_identifier_text" />
+  <copyField source="local_digital_identifier" dest="local_digital_identifier_facet" />
+  <copyField source="edition_revision_information" dest="edition_revision_information_facet" />
 
   <!-- Non-core Recommended -->
   <field name="alternative_title" type="text_general" indexed="true" stored="true" multiValued="true" />
@@ -286,20 +299,29 @@
   <copyField source="spatial" dest="spatial_facet" />
 
   <!-- Non-core Optional -->
-  <field name="source_collection" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="original_resource" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="notes" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="origin" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="audience_level" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="classification" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="physical_item_identifier" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="physical_item_location" type="text_general" indexed="true" stored="true" multiValued="true" />
+  <field name="source_collection" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="original_resource" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="notes" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="origin" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="audience_level" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="classification" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="physical_item_identifier" type="string" indexed="true" stored="true" multiValued="true" />
+  <field name="physical_item_location" type="string" indexed="true" stored="true" multiValued="true" />
 
+  <copyField source="source_collection" dest="source_collection_facet" />
+  <copyField source="origin" dest="origin_text" />
+  <copyField source="origin" dest="origin_facet" />
   <copyField source="notes" dest="_text_" />
   <copyField source="notes" dest="_text_ws" />
   <copyField source="notes" dest="notes_facet" />
+  <copyField source="notes" dest="notes_text" />
   <copyField source="notes" dest="notes_text_en_split" />
+  <copyField source="audience_level" dest="audience_level_text" />
+  <copyField source="audience_level" dest="audience_level_facet" />
   <copyField source="classification" dest="_text_" />
   <copyField source="classification" dest="_text_ws" />
+  <copyField source="classification" dest="classification_text" />
   <copyField source="classification" dest="classification_facet" />
+  <copyField source="physical_item_identifier" dest="physical_item_identifier_facet" />
+  <copyField source="physical_item_location" dest="physical_item_location_facet" />
 </schema>

--- a/solr/configsets/sage-1_0/conf/managed-schema.xml
+++ b/solr/configsets/sage-1_0/conf/managed-schema.xml
@@ -199,9 +199,9 @@
   <!-- Everything below is added for compatibility with older style, remove these when no longer needed. -->
 
   <!-- Internal -->
-  <field name="collection" type="string" indexed="true" stored="true" multiValued="false" required="true" />
+  <field name="collection" type="string" indexed="true" stored="true" multiValued="true" required="true" />
   <field name="thumbnail" type="string" indexed="true" stored="true" multiValued="false" />
-  <field name="resource" type="string" indexed="true" stored="true" multiValued="false" />
+  <field name="resource" type="string" indexed="true" stored="true" multiValued="true" />
   <field name="manifest" type="string" indexed="true" stored="true" multiValued="false" />
   <field name="application_type" type="text_general" indexed="true" stored="true" multiValued="false" />
 

--- a/solr/configsets/sage-1_0/conf/managed-schema.xml
+++ b/solr/configsets/sage-1_0/conf/managed-schema.xml
@@ -227,8 +227,8 @@
   <!-- Mandatory if applicable and available (MA) -->
   <field name="subject" type="text_general" indexed="true" stored="true" multiValued="true" />
   <field name="creator" type="text_general" indexed="true" stored="true" multiValued="true" />
-  <field name="date_published" type="date" indexed="true" stored="true" multiValued="false" />
-  <field name="date_created" type="date" indexed="true" stored="true" multiValued="false" />
+  <field name="date_published" type="string" indexed="true" stored="true" multiValued="false" />
+  <field name="date_created" type="string" indexed="true" stored="true" multiValued="false" />
   <field name="summary_abstract" type="text_general" indexed="true" stored="true" multiValued="true" />
   <field name="language" type="text_general" indexed="true" stored="true" multiValued="true" />
   <field name="institution_department" type="text_general" indexed="true" stored="true" multiValued="true" />

--- a/solr/configsets/sage-1_0/conf/managed-schema.xml
+++ b/solr/configsets/sage-1_0/conf/managed-schema.xml
@@ -81,15 +81,15 @@
   <dynamicField name="*_whole_si_t" type="whole" indexed="true" stored="true" multiValued="false" />
 
   <!-- Special / Core field types. -->
-  <fieldType name="binary" class="solr.BinaryField" multiValued="true" />
-  <fieldType name="bool" class="solr.BoolField" sortMissingLast="true" multiValued="true" />
-  <fieldType name="date" class="solr.DatePointField" docValues="true" multiValued="true" />
-  <fieldType name="double" class="solr.DoublePointField" docValues="true" multiValued="true" />
-  <fieldType name="float" class="solr.FloatPointField" docValues="true" multiValued="true" />
-  <fieldType name="int" class="solr.IntPointField" docValues="true" multiValued="true" />
-  <fieldType name="long" class="solr.LongPointField" docValues="true" multiValued="true" />
-  <fieldType name="random" class="solr.RandomSortField" indexed="true" multiValued="true" />
-  <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" multiValued="true" />
+  <fieldType name="binary" class="solr.BinaryField" />
+  <fieldType name="bool" class="solr.BoolField" sortMissingLast="true" />
+  <fieldType name="date" class="solr.DatePointField" docValues="true" />
+  <fieldType name="double" class="solr.DoublePointField" docValues="true" />
+  <fieldType name="float" class="solr.FloatPointField" docValues="true" />
+  <fieldType name="int" class="solr.IntPointField" docValues="true" />
+  <fieldType name="long" class="solr.LongPointField" docValues="true" />
+  <fieldType name="random" class="solr.RandomSortField" indexed="true" />
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
 
   <!-- Special Multi-valued used in solrconfig.xml -->
   <fieldType name="pdates" class="solr.DatePointField" docValues="true" multiValued="true" />
@@ -199,10 +199,10 @@
   <!-- Everything below is added for compatibility with older style, remove these when no longer needed. -->
 
   <!-- Internal -->
-  <field name="collection" type="whole" indexed="true" stored="true" multiValued="false" required="true" />
-  <field name="thumbnail" type="whole" indexed="true" stored="true" multiValued="false" />
-  <field name="resource" type="whole" indexed="true" stored="true" multiValued="false" />
-  <field name="manifest" type="whole" indexed="true" stored="true" multiValued="false" />
+  <field name="collection" type="string" indexed="true" stored="true" multiValued="false" required="true" />
+  <field name="thumbnail" type="string" indexed="true" stored="true" multiValued="false" />
+  <field name="resource" type="string" indexed="true" stored="true" multiValued="false" />
+  <field name="manifest" type="string" indexed="true" stored="true" multiValued="false" />
   <field name="application_type" type="text_general" indexed="true" stored="true" multiValued="false" />
 
   <copyField source="application_type" dest="application_type_facet" />

--- a/solr/configsets/sage-1_0/conf/solrconfig.xml
+++ b/solr/configsets/sage-1_0/conf/solrconfig.xml
@@ -976,7 +976,7 @@
       <str name="valueClass">java.lang.String</str>
       <str name="fieldType">text_general</str>
       <lst name="copyField">
-        <str name="dest">*_str</str>
+        <str name="dest">*_string</str>
         <int name="maxChars">256</int>
       </lst>
       <!-- Use as default mapping instead of defaultFieldType -->


### PR DESCRIPTION
# Description

Using the incorrect copyfield name results in a failure when populating the index.

The filter query does not work as expected for "whole" strings.
Change these "whole" strings used in core types to "string" (this will need further runtime testing).

The PR #549 introduced the "multivalue" field across the board.
Play it safe and do not add the explicit "multivalue" attribute to the core types.

The date type cannot be used for `date_published` and `date_created` because the provided dates may not be in a supported format.

Both `collection` and `resource` are multivalued in DSpace.
Change the solr core to support multiple values for both `collection` and `resource`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] solr 9.3 and sage runtime.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

