### PR TITLE
Do not restrict fields filter to fields that have data types populated.

### DIFF
--- a/src/main/java/edu/tamu/sage/service/SolrSourceService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrSourceService.java
@@ -85,20 +85,11 @@ public class SolrSourceService implements SourceService {
             luke.setNumTerms(0);
             LukeResponse lr = luke.process(solr);
 
-            // lookup solr document using filter to only gets available fields used in this scope
-            SolrQuery query = new SolrQuery();
-            query.setRows(1);
-
             for (FieldInfo info : lr.getFieldInfo().values()) {
                 SolrField field = SolrField.from(info);
 
                 if (!info.getName().contains("*") && !info.getName().equals("_version_")) {
-                    String q = String.format("%s AND %s:*", filter, info.getName());
-                    query.setQuery(q);
-                    QueryResponse qr = solr.query(query);
-                    if (qr.getResults().size() > 0) {
-                        fields.add(field);
-                    }
+                    fields.add(field);
                 }
             }
             return fields.stream();

--- a/src/main/java/edu/tamu/sage/service/SolrSourceService.java
+++ b/src/main/java/edu/tamu/sage/service/SolrSourceService.java
@@ -85,13 +85,12 @@ public class SolrSourceService implements SourceService {
             luke.setNumTerms(0);
             LukeResponse lr = luke.process(solr);
 
-            for (FieldInfo info : lr.getFieldInfo().values()) {
-                SolrField field = SolrField.from(info);
-
-                if (!info.getName().contains("*") && !info.getName().equals("_version_")) {
-                    fields.add(field);
+            lr.getFieldInfo().forEach((key, value) -> {
+                if (!value.getName().contains("*") && !value.getName().equals("_version_")) {
+                    fields.add(SolrField.from(value));
                 }
-            }
+            });
+
             return fields.stream();
         } catch (ConnectException | SolrServerException e) {
             throw new SourceNotFoundException("Could not connect to the core, uri: " + uri, e);


### PR DESCRIPTION
# Description

In practice, restricting the fields to only ones that have data makes the UI hard to use. Trying to configure a Discovery View is causing problems with being unable to select the data. Dynamic fields that are not stored may not show up when they should be available.

This change makes the field display more consistently and allows for all fields to be seen and selected from.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Localhost runtime with real data.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

